### PR TITLE
Decrease Database Receive poll to 100miliseconds

### DIFF
--- a/src/main/server/constants.ts
+++ b/src/main/server/constants.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_POLL_FREQUENCY_MS = 1000;
+export const DEFAULT_POLL_FREQUENCY_MS = 100;


### PR DESCRIPTION
# The Problem

Message responses can take up to 1 second before being sent to clients

# What your code solves

My code decreases the time between message queries and allows for a much faster-receiving rate of messages to clients

# How you fixed it
Decreased the default poll time for all message listeners

# Notes:
This may affect the outgoing message listener in an unpredictable way, there are multiple hardcoded artificial delays bigger or the same as 200ms inside of the outgoing lister.