### PR TITLE
Remove message match race condition POC

### DIFF
--- a/bluebubbles-server/src/server/api/v1/apple/actions.ts
+++ b/bluebubbles-server/src/server/api/v1/apple/actions.ts
@@ -166,7 +166,7 @@ export class ActionHandler {
         // Create the awaiter
         let messageAwaiter = null;
         if (isNotEmpty(message)) {
-            messageAwaiter = new MessagePromise(chatGuid, message, false, now);
+            messageAwaiter = new MessagePromise(chatGuid, message, false, now, tempGuid);
             Server().log(`Adding await for chat: "${chatGuid}"; text: ${messageAwaiter.text}`);
             Server().messageManager.add(messageAwaiter);
         }
@@ -181,7 +181,7 @@ export class ActionHandler {
         // Create the awaiter
         let attachmentAwaiter = null;
         if (attachment && isNotEmpty(aName)) {
-            attachmentAwaiter = new MessagePromise(chatGuid, `->${aName}`, true, now);
+            attachmentAwaiter = new MessagePromise(chatGuid, `->${aName}`, true, now, attachmentGuid);
             Server().log(`Adding await for chat: "${chatGuid}"; attachment: ${aName}`);
             Server().messageManager.add(attachmentAwaiter);
         }
@@ -192,24 +192,13 @@ export class ActionHandler {
 
         // Wait for the attachment first
         if (attachmentAwaiter) {
-            const sentAttachment = await attachmentAwaiter.promise;
+            await attachmentAwaiter.promise;
 
-            // If we have a sent message and we have a tempGuid, we need to emit the message match event
-            if (sentAttachment && isNotEmpty(attachmentGuid)) {
-                Server().httpService.sendCache.remove(attachmentGuid);
-                Server().emitMessageMatch(sentAttachment, attachmentGuid);
-            }
         }
 
         // Next, wait for the message
         if (messageAwaiter) {
-            const sentMessage = await messageAwaiter.promise;
-
-            // If we have a sent message and we have a tempGuid, we need to emit the message match event
-            if (sentMessage && isNotEmpty(tempGuid)) {
-                Server().httpService.sendCache.remove(tempGuid);
-                Server().emitMessageMatch(sentMessage, tempGuid);
-            }
+            await messageAwaiter.promise;
         }
     };
 

--- a/bluebubbles-server/src/server/api/v1/interfaces/messageInterface.ts
+++ b/bluebubbles-server/src/server/api/v1/interfaces/messageInterface.ts
@@ -52,7 +52,7 @@ export class MessageInterface {
 
         // We need offsets here due to iMessage's save times being a bit off for some reason
         const now = new Date(new Date().getTime() - 10000).getTime(); // With 10 second offset
-        const awaiter = new MessagePromise(chatGuid, message, false, now, subject);
+        const awaiter = new MessagePromise(chatGuid, message, false, now, subject, tempGuid);
 
         // Add the promise to the manager
         Server().log(`Adding await for chat: "${chatGuid}"; text: ${awaiter.text}`);
@@ -74,11 +74,6 @@ export class MessageInterface {
             );
         } else {
             throw new Error(`Invalid send method: ${method}`);
-        }
-
-        // If we have a sent message and we have a tempGuid, we need to emit the message match event
-        if (sentMessage && isNotEmpty(tempGuid)) {
-            Server().emitMessageMatch(sentMessage, tempGuid);
         }
 
         return sentMessage;
@@ -118,21 +113,14 @@ export class MessageInterface {
 
         // We need offsets here due to iMessage's save times being a bit off for some reason
         const now = new Date(new Date().getTime() - 10000).getTime(); // With 10 second offset
-        const awaiter = new MessagePromise(chatGuid, `->${aName}`, true, now);
+        const awaiter = new MessagePromise(chatGuid, `->${aName}`, true, now, attachmentGuid);
 
         // Add the promise to the manager
         Server().messageManager.add(awaiter);
 
         // Send the message
         await ActionHandler.sendMessageHandler(chatGuid, "", newPath);
-        const sentMessage = await awaiter.promise;
-
-        // If we have a sent message and we have a tempGuid, we need to emit the message match event
-        if (sentMessage && isNotEmpty(attachmentGuid)) {
-            Server().emitMessageMatch(sentMessage, attachmentGuid);
-        }
-
-        return sentMessage;
+        return await awaiter.promise;
     }
 
     static async sendMessagePrivateApi(
@@ -216,7 +204,7 @@ export class MessageInterface {
 
         // We need offsets here due to iMessage's save times being a bit off for some reason
         const now = new Date(new Date().getTime() - 10000).getTime(); // With 10 second offset
-        const awaiter = new MessagePromise(chatGuid, messageText, false, now);
+        const awaiter = new MessagePromise(chatGuid, messageText, false, now, tempGuid);
         Server().messageManager.add(awaiter);
 
         // Send the reaction
@@ -253,10 +241,6 @@ export class MessageInterface {
             throw new Error("Failed to send reaction! Message not found after 5 seconds!");
         }
 
-        // If we have a sent message and we have a tempGuid, we need to emit the message match event
-        if (retMessage && isNotEmpty(tempGuid)) {
-            Server().emitMessageMatch(retMessage, tempGuid);
-        }
 
         // Return the message
         return retMessage;

--- a/bluebubbles-server/src/server/databases/imessage/listeners/outgoingMessageListener.ts
+++ b/bluebubbles-server/src/server/databases/imessage/listeners/outgoingMessageListener.ts
@@ -136,21 +136,17 @@ export class OutgoingMessageListener extends ChangeListener {
             // Resolve the promise for sent messages from a client
             const idx = Server().messageManager.findIndex(entry);
             if (idx >= 0) {
-                Server().messageManager.promises[idx].resolve(entry);
+                await Server().messageManager.promises[idx].resolve(entry);
+                // After the MessageMatchEmit event reaches client, then emmit new-entry to fcm
 
-                // If we have a message match, we want the message match event to
-                // get to the clients first, so I'm adding an artificial delay.
-                // This _only_ applies when a message match is found, meaning you
-                // sent it from a client
-                setTimeout(() => {
-                    super.emit("new-entry", entry);
-                }, 1000);
+                super.emit("new-entry", entry);
+
             } else {
                 // If it's not associated with a promise, emit it as normal
                 super.emit("new-entry", entry);
 
                 // Add artificial delay so we don't overwhelm any listeners
-                await waitMs(200);
+                // Not need, not even included in the incoming message listener
             }
         }
 
@@ -170,7 +166,7 @@ export class OutgoingMessageListener extends ChangeListener {
             if (idx >= 0) {
                 Server().messageManager.promises[idx].reject(entry);
 
-                setTimeout(() => {
+                setTimeout(() => { // Is this needed? What is the functionality of errors on receive
                     super.emit("message-send-error", entry);
                 }, 1000);
             } else {
@@ -212,17 +208,16 @@ export class OutgoingMessageListener extends ChangeListener {
             // Resolve the promise
             const idx = Server().messageManager.findIndex(entry);
             if (idx >= 0) {
-                Server().messageManager.promises[idx].resolve(entry);
+                await Server().messageManager.promises[idx].resolve(entry);
 
-                setTimeout(() => {
-                    super.emit("updated-entry", entry);
-                }, 1000);
+                super.emit("updated-entry", entry);
+
             } else {
                 // Emit the message
                 super.emit("updated-entry", entry);
 
                 // Add artificial delay so we don't overwhelm any listeners
-                await waitMs(200);
+                // Not need, not even included in the incoming message listener
             }
         }
     }

--- a/bluebubbles-server/src/server/managers/outgoingMessageManager/messagePromise.ts
+++ b/bluebubbles-server/src/server/managers/outgoingMessageManager/messagePromise.ts
@@ -24,7 +24,13 @@ export class MessagePromise {
 
     isAttachment: boolean;
 
-    constructor(chatGuid: string, text: string, isAttachment: boolean, sentAt: Date | number, subject?: string) {
+    private tempGUID?: string | null;
+
+    constructor(chatGuid: string, text: string, isAttachment: boolean, sentAt: Date | number, subject?: string, tempGUID?: string) {
+
+        // Used to temporarily update the guid
+        this.tempGUID = tempGUID;
+
         // Create a promise and save the "callbacks"
         this.promise = new Promise((resolve, reject) => {
             this.resolvePromise = resolve;
@@ -64,14 +70,23 @@ export class MessagePromise {
         );
     }
 
-    resolve(value: Message | PromiseLike<Message>) {
+    async resolve(value: Message) {
         this.isResolved = true;
+        await this.updateMessageMatch(value);
         this.resolvePromise(value);
     }
 
     reject(reason?: any) {
         this.isResolved = true;
         this.rejectPromise(reason);
+    }
+
+    async updateMessageMatch(sentMessage: Message) {
+        // If we have a sent message and we have a tempGuid, we need to emit the message match event
+        if (sentMessage && isNotEmpty(this.tempGUID)) {
+            Server().httpService.sendCache.remove(this.tempGUID);
+            await Server().emitMessageMatch(sentMessage, this.tempGUID);
+        }
     }
 
     isSame(message: Message) {


### PR DESCRIPTION
MessageMatcheEventEmits should be done on completion of its attached MessagePromise. Artificial delays can be removed from the OutgoingMessageListener as long as this line `Server().messageManager.promises[idx].resolve(entry)` resolves after its message match event has been emitted to clients.