### PR TITLE
Remove unimplemented transaction

### DIFF
--- a/bluebubbles-server/src/server/services/privateApi/index.ts
+++ b/bluebubbles-server/src/server/services/privateApi/index.ts
@@ -319,8 +319,7 @@ export class BlueBubblesHelperService {
             throw new Error("Failed to retreive typing status, no chatGuid specified!");
         }
 
-        const request = new TransactionPromise(TransactionType.CHAT);
-        return this.writeData("check-typing-status", { chatGuid }, request);
+        return this.writeData("check-typing-status", { chatGuid });
     }
 
     setupListeners() {


### PR DESCRIPTION
In the blue bubbles helper, transactions are not implemented for the `check-typing-status` event. Event responses are also not returned with this event name and are returned as `stoped-typing-event` which is already handled. 

Adding this event as a transaction is definitely the better option and should be a future goal but currently isn't implemented in the blue bubbles helper and should be removed for the time being.