### PR TITLE
Fix Private Messaging Updates

### DIFF
--- a/bluebubbles-server/src/server/databases/imessage/listeners/outgoingMessageListener.ts
+++ b/bluebubbles-server/src/server/databases/imessage/listeners/outgoingMessageListener.ts
@@ -128,7 +128,7 @@ export class OutgoingMessageListener extends ChangeListener {
             const cacheName = getCacheName(entry);
 
             // Skip over any that we've finished
-            if (this.cache.find(cacheName)) return;
+            if (this.cache.find(cacheName)) continue;
 
             // Add to cache
             this.cache.add(cacheName);
@@ -160,7 +160,7 @@ export class OutgoingMessageListener extends ChangeListener {
             const cacheName = getCacheName(entry);
 
             // Skip over any that we've finished
-            if (this.cache.find(cacheName)) return;
+            if (this.cache.find(cacheName)) continue;
 
             // Add to cache
             this.cache.add(cacheName);
@@ -204,7 +204,7 @@ export class OutgoingMessageListener extends ChangeListener {
             const cacheName = `updated-${getCacheName(entry)}`;
 
             // Skip over any that we've finished
-            if (this.cache.find(cacheName)) return;
+            if (this.cache.find(cacheName)) continue;
 
             // Add to cache
             this.cache.add(cacheName);


### PR DESCRIPTION
There is a bug where private messages don't update their status. This is because private messages send so fast that a new race condition existed between the outgoing message listener and the sending of private messages. If private messages were sent and delivered faster than the speed that the outgoing message listener refreshes its database the new outgoing message listener would cache the 'new message'. This message would then block updates to themselves and others because of the cache return statements.  A race to be the first in the cache and new messages almost always win

Notes:  There is still a possibility for a race condition where an updated message listener triggers on a new-message 