### PR TITLE
v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bluebubbles-server",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "BlueBubbles Server is the app that powers the BlueBubbles app ecosystem",
     "private": true,
     "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bluebubbles/server",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "main": "./dist/main.js",
     "license": "Apache-2.0",
     "author": {
@@ -102,7 +102,7 @@
         "macos-version": "^5.2.0",
         "mime-types": "^2.1.32",
         "minimist": "^1.2.6",
-        "ngrok": "^4.3.1",
+        "ngrok": "^4.3.3",
         "node-forge": "^1.3.1",
         "node-mac-contacts": "^1.6.0",
         "node-mac-permissions": "^2.2.1",

--- a/packages/server/src/server/api/v1/interfaces/chatInterface.ts
+++ b/packages/server/src/server/api/v1/interfaces/chatInterface.ts
@@ -4,6 +4,7 @@ import {
     checkPrivateApiStatus,
     isEmpty,
     isMinBigSur,
+    isMinVentura,
     isNotEmpty,
     resultAwaiter,
     slugifyAddress
@@ -285,7 +286,10 @@ export class ChatInterface {
     }
 
     static async markUnread(chatGuid: string): Promise<void> {
-        await Server().privateApiHelper.markChatUnread(chatGuid);
+        if (isMinVentura) {
+            await Server().privateApiHelper.markChatUnread(chatGuid);
+        }
+
         await Server().emitMessage(CHAT_READ_STATUS_CHANGED, {
             chatGuid,
             read: false

--- a/packages/server/src/server/api/v1/interfaces/chatInterface.ts
+++ b/packages/server/src/server/api/v1/interfaces/chatInterface.ts
@@ -51,7 +51,15 @@ export class ChatInterface {
 
         const results = [];
         for (const chat of chats ?? []) {
-            const chatRes = await ChatSerializer.serialize({ chat });
+            const chatRes = await ChatSerializer.serialize({
+                chat,
+                config: { includeMessages: withLastMessage },
+                messageConfig: {
+                    parseAttributedBody: true,
+                    parseMessageSummary: true,
+                    parsePayloadData: true
+                }
+            });
 
             // Insert the cached participants from the original request
             if (Object.keys(chatCache).includes(chat.guid)) {

--- a/packages/server/src/server/api/v1/serializers/AttachmentSerializer.ts
+++ b/packages/server/src/server/api/v1/serializers/AttachmentSerializer.ts
@@ -55,14 +55,6 @@ export class AttachmentSerializer {
         // If the attachment isn't finished downloading, the path will be null
         if (fPath) {
             try {
-                Server().log(
-                    `Handling attachment response for GUID: ${attachment.guid} (Original: ${
-                        attachment.originalGuid ?? "N/A"
-                    })`,
-                    "debug"
-                );
-                Server().log(`Detected MIME Type: ${mimeType}`, "debug");
-
                 // If we want to resize the image, do so here
                 if (config.convert) {
                     const converters = [convertImage, convertAudio];

--- a/packages/server/src/server/api/v1/serializers/MessageSerializer.ts
+++ b/packages/server/src/server/api/v1/serializers/MessageSerializer.ts
@@ -81,7 +81,7 @@ export class MessageSerializer {
         // The parse options are enforced _after_ the convert function is called.
         // This is so that we can properly extract the text from the attributed body
         // for those on macOS Ventura. Otherwise, set it to null to not clutter the payload.
-        if (!config.parseAttributedBody || !config.parseMessageSummary) {
+        if (!config.parseAttributedBody || !config.parseMessageSummary || !config.parsePayloadData) {
             for (let i = 0; i < messageResponses.length; i++) {
                 if (!config.parseAttributedBody && "attributedBody" in messageResponses[i]) {
                     messageResponses[i].attributedBody = null;
@@ -89,6 +89,10 @@ export class MessageSerializer {
 
                 if (!config.parseMessageSummary && "messageSummaryInfo" in messageResponses[i]) {
                     messageResponses[i].messageSummaryInfo = null;
+                }
+
+                if (!config.parsePayloadData && "payloadData" in messageResponses[i]) {
+                    messageResponses[i].payloadData = null;
                 }
             }
         }
@@ -141,6 +145,7 @@ export class MessageSerializer {
             dateRead: message.dateRead ? message.dateRead.getTime() : null,
             dateDelivered: message.dateDelivered ? message.dateDelivered.getTime() : null,
             isFromMe: message.isFromMe,
+            hasDdResults: message.hasDdResults,
             isArchived: message.isArchived,
             itemType: message.itemType,
             groupTitle: message.groupTitle,
@@ -149,7 +154,8 @@ export class MessageSerializer {
             associatedMessageGuid: message.associatedMessageGuid,
             associatedMessageType: message.associatedMessageType,
             expressiveSendStyleId: message.expressiveSendStyleId,
-            threadOriginatorGuid: message.threadOriginatorGuid
+            threadOriginatorGuid: message.threadOriginatorGuid,
+            hasPayloadData: !!message.payloadData
         };
 
         if (!isForNotification) {
@@ -168,7 +174,6 @@ export class MessageSerializer {
                     cacheRoomnames: message.cacheRoomnames,
                     isSpam: message.isSpam,
                     isExpired: message.isExpirable,
-                    hasDdResults: message.hasDdResults,
                     timeExpressiveSendStyleId: message.timeExpressiveSendStyleId
                         ? message.timeExpressiveSendStyleId.getTime()
                         : null,
@@ -188,6 +193,7 @@ export class MessageSerializer {
 
         if (isMinHighSierra) {
             output.messageSummaryInfo = message.messageSummaryInfo;
+            output.payloadData = message.payloadData;
         }
 
         if (isMinVentura) {

--- a/packages/server/src/server/api/v1/serializers/constants.ts
+++ b/packages/server/src/server/api/v1/serializers/constants.ts
@@ -8,6 +8,7 @@ export const DEFAULT_ATTACHMENT_CONFIG = {
 export const DEFAULT_MESSAGE_CONFIG = {
     parseAttributedBody: false,
     parseMessageSummary: false,
+    parsePayloadData: false,
     loadChatParticipants: true,
     includeChats: true,
     enforceMaxSize: false,

--- a/packages/server/src/server/api/v1/serializers/types.ts
+++ b/packages/server/src/server/api/v1/serializers/types.ts
@@ -23,6 +23,7 @@ export interface HandleSerializerParams {
 export interface MessageSerializerParams {
     parseAttributedBody?: boolean;
     parseMessageSummary?: boolean;
+    parsePayloadData?: boolean;
     includeChats?: boolean;
     loadChatParticipants?: boolean;
     enforceMaxSize?: boolean;

--- a/packages/server/src/server/databases/imessage/entity/Message.ts
+++ b/packages/server/src/server/databases/imessage/entity/Message.ts
@@ -434,8 +434,16 @@ export class Message {
     @conditional(isMinHighSierra, Column({ name: "balloon_bundle_id", type: "text", nullable: true }))
     balloonBundleId: string;
 
-    @conditional(isMinHighSierra, Column({ name: "payload_data", type: "blob", nullable: true }))
-    payloadData: Blob;
+    @conditional(
+        isMinHighSierra,
+        Column({
+            name: "payload_data",
+            type: "blob",
+            nullable: true,
+            transformer: AttributedBodyTransformer
+        })
+    )
+    payloadData: NodeJS.Dict<any>[] | null;
 
     @conditional(isMinHighSierra, Column({ name: "expressive_send_style_id", type: "text", nullable: true }))
     expressiveSendStyleId: string;

--- a/packages/server/src/server/services/httpService/api/v1/routers/chatRouter.ts
+++ b/packages/server/src/server/services/httpService/api/v1/routers/chatRouter.ts
@@ -79,6 +79,7 @@ export class ChatRouter {
             "messages.messageSummaryInfo",
             "messages.message-summary-info"
         ]);
+        const withPayloadData = arrayHasOne(withQuery, ["message.payloadData", "message.payload-data"]);
         const { sort, before, after, offset, limit } = ctx?.request.query ?? {};
 
         const chats = await Server().iMessageRepo.getChats({
@@ -107,7 +108,8 @@ export class ChatRouter {
             config: {
                 loadChatParticipants: false,
                 parseAttributedBody: withAttributedBody,
-                parseMessageSummary: withMessageSummaryInfo
+                parseMessageSummary: withMessageSummaryInfo,
+                parsePayloadData: withPayloadData
             }
         });
 

--- a/packages/server/src/server/services/httpService/api/v1/routers/messageRouter.ts
+++ b/packages/server/src/server/services/httpService/api/v1/routers/messageRouter.ts
@@ -50,6 +50,7 @@ export class MessageRouter {
         const withAttachments = arrayHasOne(withQuery, ["attachment", "attachments"]);
         const withAttributedBody = arrayHasOne(withQuery, ["attributedBody", "attributed-body"]);
         const withMessageSummaryInfo = arrayHasOne(withQuery, ["messageSummaryInfo", "message-summary-info"]);
+        const withPayloadData = arrayHasOne(withQuery, ["payloadData", "payload-data"]);
 
         // Fetch the info for the message by GUID
         const message = await Server().iMessageRepo.getMessage(guid, withChats, withAttachments);
@@ -75,7 +76,8 @@ export class MessageRouter {
                 message,
                 config: {
                     parseAttributedBody: withAttributedBody,
-                    parseMessageSummary: withMessageSummaryInfo
+                    parseMessageSummary: withMessageSummaryInfo,
+                    parsePayloadData: withPayloadData
                 }
             })
         }).send();
@@ -103,6 +105,7 @@ export class MessageRouter {
         const withChatParticipants = arrayHasOne(withQuery, ["chat.participants", "chats.participants"]);
         const withAttributedBody = arrayHasOne(withQuery, ["attributedbody", "attributed-body"]);
         const withMessageSummaryInfo = arrayHasOne(withQuery, ["messageSummaryInfo", "message-summary-info"]);
+        const withPayloadData = arrayHasOne(withQuery, ["payloadData", "payload-data"]);
 
         // We don't need to worry about it not being a number because
         // the validator checks for that. It also checks for min values.
@@ -141,6 +144,7 @@ export class MessageRouter {
             config: {
                 parseAttributedBody: withAttributedBody,
                 parseMessageSummary: withMessageSummaryInfo,
+                parsePayloadData: withPayloadData,
                 loadChatParticipants: withChatParticipants
             }
         });
@@ -181,7 +185,8 @@ export class MessageRouter {
                 config: {
                     loadChatParticipants: false,
                     parseAttributedBody: true,
-                    parseMessageSummary: true
+                    parseMessageSummary: true,
+                    parsePayloadData: true
                 }
             });
 
@@ -262,7 +267,8 @@ export class MessageRouter {
                 config: {
                     loadChatParticipants: false,
                     parseAttributedBody: true,
-                    parseMessageSummary: true
+                    parseMessageSummary: true,
+                    parsePayloadData: true
                 }
             });
             return new Success(ctx, { message: "Attachment sent!", data }).send();
@@ -320,7 +326,8 @@ export class MessageRouter {
                     config: {
                         loadChatParticipants: false,
                         parseAttributedBody: true,
-                        parseMessageSummary: true
+                        parseMessageSummary: true,
+                        parsePayloadData: true
                     }
                 })
             }).send();
@@ -379,7 +386,8 @@ export class MessageRouter {
                     config: {
                         loadChatParticipants: false,
                         parseAttributedBody: true,
-                        parseMessageSummary: true
+                        parseMessageSummary: true,
+                        parsePayloadData: true
                     }
                 })
             }).send();
@@ -445,7 +453,8 @@ export class MessageRouter {
                     config: {
                         loadChatParticipants: false,
                         parseAttributedBody: true,
-                        parseMessageSummary: true
+                        parseMessageSummary: true,
+                        parsePayloadData: true
                     }
                 })
             }).send();

--- a/packages/server/src/server/types.ts
+++ b/packages/server/src/server/types.ts
@@ -64,6 +64,8 @@ export type MessageResponse = {
     dateRetracted?: number | null;
     dateEdited?: number | null;
     partCount?: number | null;
+    payloadData?: NodeJS.Dict<any>[];
+    hasPayloadData?: boolean;
 };
 
 export type HandleResponse = {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bluebubbles/ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "./",
   "license": "Apache-2.0",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7724,7 +7724,7 @@ google-p12-pem@^4.0.0:
   dependencies:
     node-forge "^1.3.1"
 
-got@^11.5.1, got@^11.7.0:
+got@^11.7.0, got@^11.8.5:
   version "11.8.5"
   resolved "https://registry.npmjs.org/got/-/got-11.8.5.tgz"
   integrity sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==
@@ -10175,14 +10175,14 @@ neo-async@^2.6.2:
   resolved "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-ngrok@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/ngrok/-/ngrok-4.3.1.tgz"
-  integrity sha512-s0joO2liKYiGTVARyzL8hfLIXAZT03GDK3oJqsZK6d61Es+HCx77j8E9ysUbtkMEyvBgYmIMr8taQNsvQt4/DQ==
+ngrok@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/ngrok/-/ngrok-4.3.3.tgz#c51a1c4af2271ac3c9092ede3b0975caf7833217"
+  integrity sha512-a2KApnkiG5urRxBPdDf76nNBQTnNNWXU0nXw0SsqsPI+Kmt2lGf9TdVYpYrHMnC+T9KhcNSWjCpWqBgC6QcFvw==
   dependencies:
     "@types/node" "^8.10.50"
     extract-zip "^2.0.1"
-    got "^11.5.1"
+    got "^11.8.5"
     lodash.clonedeep "^4.5.0"
     uuid "^7.0.0 || ^8.0.0"
     yaml "^1.10.0"


### PR DESCRIPTION
# What's New?

## Fixes

* Fixes issue where a chat's last message would not be returned by the API
    - This caused issues with the Web App not showing the last message preview and/or sorting issues
* Mark chat as unread API is now limited to only macOS Ventura

## Other Changes

* Message `payload data` is now decoded and sent back with API responses (when requested)