### PR TITLE
Fix: started-typing event

### DIFF
--- a/packages/server/src/server/services/privateApi/eventHandlers/PrivateApiTypingEventHandler.ts
+++ b/packages/server/src/server/services/privateApi/eventHandlers/PrivateApiTypingEventHandler.ts
@@ -9,7 +9,7 @@ export class PrivateApiTypingEventHandler implements PrivateApiEventHandler {
 
     cache: Record<string, Record<string, any>> = {};
 
-    async handle(event: any) {
+    async handle({ event }: any) {
         const display = event === "started-typing";
         const guid = event.guid;
         let shouldEmit = false;

--- a/packages/server/src/server/services/privateApi/eventHandlers/PrivateApiTypingEventHandler.ts
+++ b/packages/server/src/server/services/privateApi/eventHandlers/PrivateApiTypingEventHandler.ts
@@ -5,7 +5,7 @@ import { PrivateApiEventHandler } from ".";
 
 export class PrivateApiTypingEventHandler implements PrivateApiEventHandler {
 
-    types: string[] = ["typing", "stopped-typing"];
+    types: string[] = ["started-typing", "stopped-typing"];
 
     cache: Record<string, Record<string, any>> = {};
 

--- a/packages/server/src/server/services/privateApi/eventHandlers/PrivateApiTypingEventHandler.ts
+++ b/packages/server/src/server/services/privateApi/eventHandlers/PrivateApiTypingEventHandler.ts
@@ -9,9 +9,8 @@ export class PrivateApiTypingEventHandler implements PrivateApiEventHandler {
 
     cache: Record<string, Record<string, any>> = {};
 
-    async handle({ event }: any) {
-        const display = event === "started-typing";
-        const guid = event.guid;
+    async handle({ event, guid }: any) {
+        const display = event === "started-typing"; 
         let shouldEmit = false;
 
         // If the guid hasn't been seen before, we should emit the event


### PR DESCRIPTION
These changes get the started-typing events back up and running for my project. They are pretty critical, so was quick to notice after the 1.8 update. 

Easy-to-make typo/forget to update the event name, so I thought I'd put up a PR. Oh and I destructed the event from the object passed to the handler. Working on my end now.

Thanks for all the hard work on this project. Cheers!