### PR TITLE
Fix event type string for aliases removed event

### DIFF
--- a/packages/server/src/server/api/privateApi/eventHandlers/PrivateApiAddressEventHandler.ts
+++ b/packages/server/src/server/api/privateApi/eventHandlers/PrivateApiAddressEventHandler.ts
@@ -5,12 +5,12 @@ import { EventData, PrivateApiEventHandler } from ".";
 
 export class PrivateApiAddressEventHandler implements PrivateApiEventHandler {
 
-    types: string[] = ["alias-removed"];
+    types: string[] = ["aliases-removed"];
 
     cache: Record<string, Record<string, any>> = {};
 
     async handle(data: EventData) {
-        if (data.event === 'alias-removed') {
+        if (data.event === 'aliases-removed') {
             await this.handleDeregistration(data);
         }
     }


### PR DESCRIPTION
`PrivateApiAddressEventHandler` is using the incorrect "type" string for the alias removal event from the PrivateAPI Helper. The helper is sending "alias**es**-removed" (https://github.com/BlueBubblesApp/bluebubbles-helper/blob/master/Messages/MacOS-10/BlueBubblesHelper/BlueBubblesHelper.m#L757) but the server is looking for "alias-removed". This PR corrects the string so the server can start receiving the events. 