### PR TITLE
Add LaunchAgents directory check and mkdir

### DIFF
--- a/packages/server/src/server/fileSystem/index.ts
+++ b/packages/server/src/server/fileSystem/index.ts
@@ -746,8 +746,14 @@ export class FileSystem {
     </dict>
 </plist>`;
 
+        // As of macOS Tahoe, the directory ~/Library/LaunchAgents does not exist unless otherwise created
+        const launchAgentsPath = path.join(userHomeDir(), "Library", "LaunchAgents");
+        if (!fs.existsSync(launchAgentsPath)) {
+            fs.mkdirSync(launchAgentsPath);
+        }
+
         const plistName = "com.bluebubbles.server";
-        const filePath = path.join(userHomeDir(), "Library", "LaunchAgents", `${plistName}.plist`);
+        const filePath = path.join(launchAgentsPath, `${plistName}.plist`);
         if (!fs.existsSync(filePath)) {
             fs.writeFileSync(filePath, plist);
         }


### PR DESCRIPTION
As of macOS Tahoe, the directory `~/Library/LaunchAgents` does not exist unless otherwise created.

Therefore, if the user is setting up BlueBubbles on a brand new system running macOS Tahoe, `createLaunchAgent()` will fail silently if the directory `~/Library/LaunchAgents` has not been manually created.

This Pull Request \*I think\* should fix that. (I'm not a Node developer, so this is my best guess for how to fix this issue.)