### PR TITLE
Support macOS 15+ text formatting

### DIFF
--- a/packages/server/src/server/api/http/api/v1/routers/messageRouter.ts
+++ b/packages/server/src/server/api/http/api/v1/routers/messageRouter.ts
@@ -236,7 +236,7 @@ export class MessageRouter {
 
     static async sendText(ctx: RouterContext, _: Next) {
         let {
-            tempGuid, message, attributedBody, method, chatGuid,
+            tempGuid, message, attributedBody, textFormatting, method, chatGuid,
             effectId, subject, selectedMessageGuid, partIndex, ddScan
         } = ctx?.request?.body ?? {};
 
@@ -250,6 +250,7 @@ export class MessageRouter {
                 message,
                 method,
                 attributedBody,
+                textFormatting,
                 subject,
                 effectId,
                 selectedMessageGuid,

--- a/packages/server/src/server/api/http/api/v1/validators/messageValidator.ts
+++ b/packages/server/src/server/api/http/api/v1/validators/messageValidator.ts
@@ -7,6 +7,8 @@ import { Server } from "@server";
 import { isEmpty } from "@server/helpers/utils";
 import { FileSystem } from "@server/fileSystem";
 import { MessageInterface } from "@server/api/interfaces/messageInterface";
+import { isMinSequoia } from "@server/env";
+import { hasTextFormatting, validateTextFormatting } from "@server/utils/TextFormattingUtils";
 
 import { ValidateInput } from "./index";
 import { BadRequest } from "../responses/errors";
@@ -75,11 +77,12 @@ export class MessageValidator {
         subject: "string",
         selectedMessageGuid: "string",
         partIndex: "numeric|min:0",
-        ddScan: "boolean"
+        ddScan: "boolean",
+        textFormatting: "array"
     };
 
     static async validateText(ctx: RouterContext, next: Next) {
-        const { tempGuid, method, effectId, subject, selectedMessageGuid, message, ddScan } = ValidateInput(
+        const { tempGuid, method, effectId, subject, selectedMessageGuid, message, ddScan, textFormatting } = ValidateInput(
             ctx.request.body,
             MessageValidator.sendTextRules
         );
@@ -90,7 +93,7 @@ export class MessageValidator {
 
         // If we have an effectId, subject, reply, or attributedBody
         // let's imply we want to use the Private API
-        if (effectId || subject || selectedMessageGuid || ddScan || ctx.request.body.attributedBody) {
+        if (effectId || subject || selectedMessageGuid || ddScan || ctx.request.body.attributedBody || hasTextFormatting(textFormatting)) {
             saniMethod = "private-api";
         }
 
@@ -105,6 +108,22 @@ export class MessageValidator {
 
         if (saniMethod === "private-api" && isEmpty(message) && isEmpty(subject)) {
             throw new BadRequest({ error: `A 'message' or 'subject' is required when sending via the Private API` });
+        }
+
+        if (hasTextFormatting(textFormatting)) {
+            if (ctx.request.body.attributedBody) {
+                throw new BadRequest({ error: "Use either textFormatting or attributedBody, not both" });
+            }
+
+            if (!isMinSequoia) {
+                throw new BadRequest({ error: "Text formatting is only supported on macOS Sequoia (15) and newer" });
+            }
+
+            try {
+                validateTextFormatting(textFormatting, message);
+            } catch (ex: any) {
+                throw new BadRequest({ error: ex?.message ?? "Invalid textFormatting payload" });
+            }
         }
 
         // Inject the method (we have to force it to thing it's anything)

--- a/packages/server/src/server/api/interfaces/messageInterface.ts
+++ b/packages/server/src/server/api/interfaces/messageInterface.ts
@@ -4,11 +4,12 @@ import { FileSystem } from "@server/fileSystem";
 import { MessagePromise } from "@server/managers/outgoingMessageManager/messagePromise";
 import { Message } from "@server/databases/imessage/entity/Message";
 import { checkPrivateApiStatus, isEmpty, isNotEmpty, resultAwaiter } from "@server/helpers/utils";
-import { isMinMonterey, isMinVentura } from "@server/env";
+import { isMinMonterey, isMinSequoia, isMinVentura } from "@server/env";
 import { negativeReactionTextMap, reactionTextMap } from "@server/api/apple/mappings";
 import { invisibleMediaChar } from "@server/api/http/constants";
 import { ActionHandler } from "@server/api/apple/actions";
 import { rimrafSync } from "rimraf";
+import { hasTextFormatting, validateTextFormatting } from "@server/utils/TextFormattingUtils";
 import type {
     SendMessageParams,
     SendAttachmentParams,
@@ -54,6 +55,7 @@ export class MessageInterface {
         message,
         method = "apple-script",
         attributedBody = null,
+        textFormatting = null,
         subject = null,
         effectId = null,
         selectedMessageGuid = null,
@@ -64,6 +66,22 @@ export class MessageInterface {
         if (!chatGuid) throw new Error("No chat GUID provided");
 
         Server().log(`Sending message "${message}" to ${chatGuid}`, "debug");
+
+        if (hasTextFormatting(textFormatting)) {
+            if (attributedBody) {
+                throw new Error("Use either textFormatting or attributedBody, not both");
+            }
+
+            if (method !== "private-api") {
+                throw new Error("Text formatting requires the Private API send method");
+            }
+
+            if (!isMinSequoia) {
+                throw new Error("Text formatting is only supported on macOS Sequoia (15) and newer");
+            }
+
+            validateTextFormatting(textFormatting, message ?? "");
+        }
 
         // We need offsets here due to iMessage's save times being a bit off for some reason
         const now = new Date(new Date().getTime() - 10000).getTime(); // With 10 second offset
@@ -103,6 +121,7 @@ export class MessageInterface {
                 chatGuid,
                 message,
                 attributedBody,
+                textFormatting,
                 subject,
                 effectId,
                 selectedMessageGuid,
@@ -225,6 +244,7 @@ export class MessageInterface {
         chatGuid,
         message,
         attributedBody = null,
+        textFormatting = null,
         subject = null,
         effectId = null,
         selectedMessageGuid = null,
@@ -236,6 +256,7 @@ export class MessageInterface {
             chatGuid,
             message,
             attributedBody ?? null,
+            textFormatting ?? null,
             subject ?? null,
             effectId ?? null,
             selectedMessageGuid ?? null,

--- a/packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts
+++ b/packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts
@@ -14,6 +14,7 @@ export class PrivateApiMessage extends PrivateApiAction {
         chatGuid: string,
         message: string,
         attributedBody: Record<string, any> = null,
+        textFormatting: Record<string, any> = null,
         subject: string = null,
         effectId: string = null,
         selectedMessageGuid: string = null,
@@ -29,6 +30,7 @@ export class PrivateApiMessage extends PrivateApiAction {
             subject,
             message,
             attributedBody,
+            textFormatting,
             effectId,
             selectedMessageGuid,
             partIndex

--- a/packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts
+++ b/packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts
@@ -4,7 +4,7 @@ import {
     TransactionType
 } from "@server/managers/transactionManager/transactionPromise";
 import { PrivateApiAction } from ".";
-import type { ValidTapback, ValidRemoveTapback } from "@server/types";
+import type { TextFormatting, ValidTapback, ValidRemoveTapback } from "@server/types";
 import { isMinCatalina, isMinMonterey } from "@server/env";
 
 export class PrivateApiMessage extends PrivateApiAction {
@@ -14,7 +14,7 @@ export class PrivateApiMessage extends PrivateApiAction {
         chatGuid: string,
         message: string,
         attributedBody: Record<string, any> = null,
-        textFormatting: Record<string, any> = null,
+        textFormatting: TextFormatting = null,
         subject: string = null,
         effectId: string = null,
         selectedMessageGuid: string = null,

--- a/packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts
+++ b/packages/server/src/server/api/privateApi/apis/PrivateApiMessage.ts
@@ -4,7 +4,8 @@ import {
     TransactionType
 } from "@server/managers/transactionManager/transactionPromise";
 import { PrivateApiAction } from ".";
-import type { TextFormatting, ValidTapback, ValidRemoveTapback } from "@server/types";
+import type { ValidTapback, ValidRemoveTapback } from "@server/types";
+import type { TextFormatting } from "@server/api/types";
 import { isMinCatalina, isMinMonterey } from "@server/env";
 
 export class PrivateApiMessage extends PrivateApiAction {

--- a/packages/server/src/server/api/types/index.ts
+++ b/packages/server/src/server/api/types/index.ts
@@ -7,6 +7,7 @@ export type SendMessageParams = {
     message: string;
     method: "apple-script" | "private-api";
     attributedBody?: Record<string, any> | null;
+    textFormatting?: TextFormatting | null;
     subject?: string;
     effectId?: string;
     selectedMessageGuid?: string;
@@ -19,6 +20,7 @@ export type SendMessagePrivateApiParams = {
     chatGuid: string;
     message: string;
     attributedBody?: Record<string, any> | null;
+    textFormatting?: TextFormatting | null;
     subject?: string;
     effectId?: string;
     selectedMessageGuid?: string;
@@ -84,6 +86,16 @@ export type SendMultipartTextParams = {
     parts: Record<string, any>[];
     ddScan?: boolean;
 };
+
+export type TextFormattingStyle = "bold" | "italic" | "underline" | "strikethrough";
+
+export type TextFormattingRange = {
+    start: number;
+    length: number;
+    styles: TextFormattingStyle[];
+};
+
+export type TextFormatting = TextFormattingRange[];
 
 export class Socket extends net.Socket {
     id: string;

--- a/packages/server/src/server/utils/TextFormattingUtils.ts
+++ b/packages/server/src/server/utils/TextFormattingUtils.ts
@@ -1,0 +1,58 @@
+import { TextFormatting, TextFormattingStyle } from "@server/api/types";
+
+export const TEXT_FORMATTING_STYLES: TextFormattingStyle[] = [
+    "bold",
+    "italic",
+    "underline",
+    "strikethrough"
+];
+
+const allowedStyles = new Set<TextFormattingStyle>(TEXT_FORMATTING_STYLES);
+
+export const hasTextFormatting = (formatting?: TextFormatting | null): boolean => {
+    return Array.isArray(formatting) && formatting.length > 0;
+};
+
+export const validateTextFormatting = (formatting: TextFormatting, message: string): void => {
+    if (!Array.isArray(formatting)) {
+        throw new Error("textFormatting must be an array");
+    }
+
+    if (typeof message !== "string" || message.length === 0) {
+        throw new Error("A non-empty 'message' is required when using textFormatting");
+    }
+
+    const messageLength = message.length;
+    for (let i = 0; i < formatting.length; i++) {
+        const range = formatting[i] as any;
+        if (!range || typeof range !== "object" || Array.isArray(range)) {
+            throw new Error(`textFormatting[${i}] must be an object`);
+        }
+
+        const start = range.start;
+        const length = range.length;
+        const styles = range.styles;
+
+        if (!Number.isInteger(start) || start < 0) {
+            throw new Error(`textFormatting[${i}].start must be an integer >= 0`);
+        }
+
+        if (!Number.isInteger(length) || length <= 0) {
+            throw new Error(`textFormatting[${i}].length must be an integer > 0`);
+        }
+
+        if (start + length > messageLength) {
+            throw new Error(`textFormatting[${i}] range exceeds message length`);
+        }
+
+        if (!Array.isArray(styles) || styles.length === 0) {
+            throw new Error(`textFormatting[${i}].styles must be a non-empty array`);
+        }
+
+        for (const style of styles) {
+            if (!allowedStyles.has(style)) {
+                throw new Error(`textFormatting[${i}].styles contains unsupported value: ${style}`);
+            }
+        }
+    }
+};


### PR DESCRIPTION
Adds support for basic text formatting (bold, italic, underline, strikethrough)

Pairs with https://github.com/BlueBubblesApp/bluebubbles-helper/pull/50

This script:

```js
const body = {
  chatGuid,
  message: "Bold Italic Underline Strike",
  method: "private-api",
  textFormatting: [
    { start: 0, length: 4, styles: ["bold"] },
    { start: 5, length: 6, styles: ["italic"] },
    { start: 12, length: 9, styles: ["underline"] },
    { start: 22, length: 6, styles: ["strikethrough"] }
  ]
};

fetch(`${baseUrl}/api/v1/message/text?password=${encodeURIComponent(password)}`, {
  method: "POST",
  headers: { "Content-Type": "application/json" },
  body: JSON.stringify(body)
})
```

Resulted in: 
<img width="199" height="48" alt="image" src="https://github.com/user-attachments/assets/79105a32-3643-4374-971e-9a8118904630" />