### PR TITLE
fix: stopTyping endpoint was calling startTyping

### DIFF
--- a/packages/server/src/server/api/http/api/v1/routers/chatRouter.ts
+++ b/packages/server/src/server/api/http/api/v1/routers/chatRouter.ts
@@ -329,7 +329,7 @@ export class ChatRouter {
 
     static async stopTyping(ctx: RouterContext, _: Next): Promise<void> {
         const { guid } = ctx.params;
-        await ChatInterface.startTyping(guid);
+        await ChatInterface.stopTyping(guid);
         return new Success(ctx, { message: `Successfully stopped typing!` }).send();
     }
 


### PR DESCRIPTION
## Summary

One-line fix: the `DELETE /chat/:guid/typing` endpoint (`stopTyping`) was calling `ChatInterface.startTyping()` instead of `ChatInterface.stopTyping()`.

## Problem

When clients call the stop typing API, typing indicators would restart instead of stop.

## Fix

```diff
-        await ChatInterface.startTyping(guid);
+        await ChatInterface.stopTyping(guid);
```

## Testing

Tested locally - typing indicators now properly stop when DELETE is called.