### PR TITLE
feat: per-thread webhook filtering by chat GUID

### DIFF
--- a/packages/server/src/server/api/http/api/v1/routers/webhookRouter.ts
+++ b/packages/server/src/server/api/http/api/v1/routers/webhookRouter.ts
@@ -13,20 +13,26 @@ export class WebhookRouter {
         const id = (ctx?.request?.query?.id) ? Number.parseInt(ctx?.request?.query?.id as string) : null;
         const webhooks = await Server().repo.getWebhooks({ url, id });
 
-        // Convert the events to a list (from json array)
+        // Convert JSON strings to arrays for the response
         for (const webhook of webhooks) {
             webhook.events = JSON.parse(webhook.events);
+            if (webhook.chatGuids) {
+                webhook.chatGuids = JSON.parse(webhook.chatGuids);
+            }
         }
 
         return new Success(ctx, { message: "Successfully fetched webhooks!", data: webhooks }).send();
     }
 
     static async create(ctx: RouterContext, _: Next) {
-        const { url, events } = ctx.request.body;
-        const webhook = await Server().repo.addWebhook(url, events);
+        const { url, events, chatGuids } = ctx.request.body;
+        const webhook = await Server().repo.addWebhook(url, events, chatGuids ?? null);
 
-        // Convert the events to a list (from json array)
+        // Convert JSON strings to arrays for the response
         webhook.events = JSON.parse(webhook.events);
+        if (webhook.chatGuids) {
+            webhook.chatGuids = JSON.parse(webhook.chatGuids);
+        }
 
         return new Success(ctx, { data: webhook, message: "Successfully created webhook!" }).send();
     }

--- a/packages/server/src/server/api/http/api/v1/validators/webhookValidator.ts
+++ b/packages/server/src/server/api/http/api/v1/validators/webhookValidator.ts
@@ -21,13 +21,14 @@ export class WebhookValidator {
 
     static createRules = {
         url: "required|string",
-        events: "required|array"
+        events: "required|array",
+        chatGuids: "array"
     };
 
     static async validateCreateWebhook(ctx: RouterContext, next: Next) {
         ValidateInput(ctx?.request?.body, WebhookValidator.createRules);
 
-        const { url, events } = ctx.request.body;
+        const { url, events, chatGuids } = ctx.request.body;
         if (url.length === 0) {
             throw new BadRequest({ error: "Webhook URL is required!" });
         } else if (!url.startsWith('http')) {
@@ -53,6 +54,15 @@ export class WebhookValidator {
 
         // Update the events
         ctx.request.body.events = validatedEvents;
+
+        // Validate chatGuids if provided
+        if (chatGuids) {
+            for (const guid of chatGuids) {
+                if (typeof guid !== "string") {
+                    throw new BadRequest({ error: "Webhook chatGuids must be strings!" });
+                }
+            }
+        }
 
         await next();
     }

--- a/packages/server/src/server/databases/server/entity/Webhook.ts
+++ b/packages/server/src/server/databases/server/entity/Webhook.ts
@@ -12,6 +12,10 @@ export class Webhook {
     @Column("text", { name: "events", nullable: false })
     events: string;
 
+    // JSON String — optional list of chat GUIDs to filter events by
+    @Column("text", { name: "chat_guids", nullable: true })
+    chatGuids: string;
+
     @CreateDateColumn()
     created: Date;
 }

--- a/packages/server/src/server/databases/server/index.ts
+++ b/packages/server/src/server/databases/server/index.ts
@@ -8,6 +8,7 @@ import { Config, Alert, Device, Queue, Webhook, Contact, ContactAddress, Schedul
 import { DEFAULT_DB_ITEMS } from "./constants";
 import { ContactTables1654432080899 } from "./migrations/1654432080899-ContactTables";
 import { ScheduledMessageTable1665083072000 } from "./migrations/1665083072000-ScheduledMessageTable";
+import { WebhookChatGuids1710720000000 } from "./migrations/1710720000000-WebhookChatGuids";
 import { AddExternalIdToContacts1750299580000 } from "./migrations/1750299580000-AddExternalIdToContacts";
 
 export type ServerConfig = { [key: string]: Date | string | boolean | number };
@@ -48,6 +49,7 @@ export class ServerRepository extends EventEmitter {
             migrations: [
                 ContactTables1654432080899,
                 ScheduledMessageTable1665083072000,
+                WebhookChatGuids1710720000000,
                 AddExternalIdToContacts1750299580000
             ],
             migrationsRun: !shouldSync,
@@ -210,25 +212,35 @@ export class ServerRepository extends EventEmitter {
         return await repo.find({ select: fields, relations: ["addresses"] });
     }
 
-    public async addWebhook(url: string, events: Array<{ label: string; value: string }>): Promise<Webhook> {
+    public async addWebhook(
+        url: string,
+        events: Array<{ label: string; value: string }>,
+        chatGuids: string[] | null = null
+    ): Promise<Webhook> {
         const repo = this.webhooks();
         const item = await repo.findOneBy({ url });
 
         // If the webhook exists, don't re-add it, just return it
         if (item) return item;
 
-        const webhook = repo.create({ url, events: JSON.stringify(events.map(e => e.value)) });
+        const webhook = repo.create({
+            url,
+            events: JSON.stringify(events.map(e => e.value)),
+            chatGuids: chatGuids ? JSON.stringify(chatGuids) : null
+        });
         return await repo.save(webhook);
     }
 
     public async updateWebhook({
         id,
         url = null,
-        events = null
+        events = null,
+        chatGuids
     }: {
         id: number;
         url: string;
         events: Array<{ label: string; value: string }>;
+        chatGuids?: string[] | null;
     }): Promise<Webhook> {
         const repo = this.webhooks();
         const item = await repo.findOneBy({ id });
@@ -236,6 +248,9 @@ export class ServerRepository extends EventEmitter {
 
         if (url) item.url = url;
         if (events) item.events = JSON.stringify(events.map(e => e.value));
+        // Unlike url/events, chatGuids can be explicitly set to null (to clear the filter),
+        // so we check for undefined to distinguish "not provided" from "clear"
+        if (chatGuids !== undefined) item.chatGuids = chatGuids ? JSON.stringify(chatGuids) : null;
 
         await repo.update(id, item);
         return item;

--- a/packages/server/src/server/databases/server/migrations/1710720000000-WebhookChatGuids.ts
+++ b/packages/server/src/server/databases/server/migrations/1710720000000-WebhookChatGuids.ts
@@ -1,0 +1,23 @@
+import { Server } from "@server";
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class WebhookChatGuids1710720000000 implements MigrationInterface {
+    name = "WebhookChatGuids1710720000000";
+
+    async up(queryRunner: QueryRunner): Promise<void> {
+        Server().log(`Migration[${this.name}] Adding chat_guids column to webhook table...`, "debug");
+
+        // Check if the column already exists (e.g., from a dev sync) before adding
+        const table = await queryRunner.query(`PRAGMA table_info("webhook");`);
+        const hasColumn = table.some((col: any) => col.name === "chat_guids");
+        if (!hasColumn) {
+            await queryRunner.query(`ALTER TABLE "webhook" ADD COLUMN "chat_guids" text;`);
+        }
+
+        Server().log(`Migration[${this.name}] Success!`, "debug");
+    }
+
+    async down(queryRunner: QueryRunner): Promise<void> {
+        // Don't do anything
+    }
+}

--- a/packages/server/src/server/services/ipcService/index.ts
+++ b/packages/server/src/server/services/ipcService/index.ts
@@ -150,13 +150,24 @@ export class IPCService extends Loggable {
 
         ipcMain.handle("get-webhooks", async (event, args) => {
             const res = await Server().repo.getWebhooks();
-            return res.map(e => ({ id: e.id, url: e.url, events: e.events, created: e.created }));
+            return res.map(e => ({
+                id: e.id,
+                url: e.url,
+                events: e.events,
+                chatGuids: e.chatGuids ? JSON.parse(e.chatGuids) : null,
+                created: e.created
+            }));
         });
 
         ipcMain.handle("create-webhook", async (event, payload) => {
-            const res = await Server().repo.addWebhook(payload.url, payload.events);
-            const output = { id: res.id, url: res.url, events: res.events, created: res.created };
-            return output;
+            const res = await Server().repo.addWebhook(payload.url, payload.events, payload?.chatGuids);
+            return {
+                id: res.id,
+                url: res.url,
+                events: res.events,
+                chatGuids: res.chatGuids ? JSON.parse(res.chatGuids) : null,
+                created: res.created
+            };
         });
 
         ipcMain.handle("delete-webhook", async (event, args) => {
@@ -164,7 +175,7 @@ export class IPCService extends Loggable {
         });
 
         ipcMain.handle("update-webhook", async (event, args) => {
-            return await Server().repo.updateWebhook({ id: args.id, url: args?.url, events: args?.events });
+            return await Server().repo.updateWebhook({ id: args.id, url: args?.url, events: args?.events, chatGuids: args?.chatGuids });
         });
 
         ipcMain.handle("contact-permission-status", async (event, _) => {

--- a/packages/server/src/server/services/webhookService/index.ts
+++ b/packages/server/src/server/services/webhookService/index.ts
@@ -15,9 +15,21 @@ export class WebhookService extends Loggable {
 
     async dispatch(event: WebhookEvent) {
         const webhooks = await Server().repo.getWebhooks();
+        const eventChatGuids = this.extractChatGuids(event.data);
+
         for (const i of webhooks) {
             const eventTypes = JSON.parse(i.events) as Array<string>;
             if (!eventTypes.includes("*") && !eventTypes.includes(event.type)) continue;
+
+            // Filter by chat GUIDs if the webhook has a chat filter configured
+            const webhookChatGuids = i.chatGuids ? JSON.parse(i.chatGuids) as Array<string> : null;
+            if (webhookChatGuids && webhookChatGuids.length > 0) {
+                // Global/system events (no chat context) are always delivered to all webhooks
+                if (eventChatGuids && !eventChatGuids.some(guid => webhookChatGuids.includes(guid))) {
+                    continue;
+                }
+            }
+
             this.log.debug(`Dispatching event to webhook: ${i.url}`);
 
             // We don't need to await this
@@ -27,6 +39,37 @@ export class WebhookService extends Loggable {
                 this.log.debug(`  -> Status Text: ${ex?.response?.statusText}`);
             });
         }
+    }
+
+    /**
+     * Extracts chat GUIDs from event data.
+     * Returns the list of chat GUIDs found, or null if the event has no chat context.
+     *
+     * Different event types store the chat GUID in different locations:
+     * - Most message/group events: data.chats[].guid
+     * - chat-read-status-changed: data.chatGuid
+     * - typing-indicator: data.guid (contains semicolons like "iMessage;-;+15551234567")
+     * - Global events (server-update, new-server, etc.): no chat context
+     */
+    private extractChatGuids(data: any): string[] | null {
+        // Most message/group events include a chats array with guid fields
+        if (data?.chats && Array.isArray(data.chats)) {
+            const guids = data.chats.map((c: any) => c.guid).filter(Boolean);
+            if (guids.length > 0) return guids;
+        }
+
+        // chat-read-status-changed uses a top-level chatGuid field
+        if (data?.chatGuid && typeof data.chatGuid === "string") {
+            return [data.chatGuid];
+        }
+
+        // typing-indicator uses a top-level guid that is a chat GUID (contains semicolons)
+        if (data?.guid && typeof data.guid === "string" && data.guid.includes(";")) {
+            return [data.guid];
+        }
+
+        // No chat context — this is a global/system event
+        return null;
     }
 
     private async sendPost(url: string, event: WebhookEvent) {

--- a/packages/ui/src/app/components/modals/AddWebhookDialog.tsx
+++ b/packages/ui/src/app/components/modals/AddWebhookDialog.tsx
@@ -11,9 +11,11 @@ import {
     FormControl,
     FormErrorMessage,
     FormLabel,
+    FormHelperText,
     Text
 } from '@chakra-ui/react';
 import { Select as MultiSelect } from 'chakra-react-select';
+import { ipcRenderer } from 'electron';
 import { FocusableElement } from '@chakra-ui/utils';
 import { webhookEventOptions } from '../../constants';
 import { MultiSelectValue } from '../../types';
@@ -47,6 +49,27 @@ export const AddWebhookDialog = ({
     const isUrlInvalid = (urlError ?? '').length > 0;
     const [eventsError, setEventsError] = useState('');
     const isEventsError = (eventsError ?? '').length > 0;
+    const [chatOptions, setChatOptions] = useState([] as Array<MultiSelectValue>);
+    const [selectedChats, setSelectedChats] = useState([] as Array<MultiSelectValue>);
+
+    useEffect(() => {
+        ipcRenderer.invoke('get-chats').then((chats: any[]) => {
+            chats.sort((a, b) => {
+                const aHasName = !!a.displayName;
+                const bHasName = !!b.displayName;
+                if (aHasName === bHasName) return 0;
+                return aHasName ? -1 : 1;
+            });
+            const options = chats.map((e: any) => {
+                let label = e.displayName ?? '';
+                if (label.length === 0) {
+                    label = e.participants?.map((p: any) => p.address).join(', ') ?? e.chatIdentifier ?? e.guid;
+                }
+                return { label, value: e.guid };
+            });
+            setChatOptions(options);
+        });
+    }, []);
 
     useEffect(() => {
         if (!existingId) return;
@@ -57,6 +80,21 @@ export const AddWebhookDialog = ({
             setSelectedEvents(convertMultiSelectValues(JSON.parse(webhook.events)));
         }
     }, [existingId]);
+
+    useEffect(() => {
+        if (!existingId) return;
+
+        const webhook = webhooks.find(e => e.id === existingId);
+        if (webhook?.chatGuids && webhook.chatGuids.length > 0) {
+            const matched = webhook.chatGuids.map(guid => {
+                const option = chatOptions.find(o => o.value === guid);
+                return option ?? { label: guid, value: guid };
+            });
+            setSelectedChats(matched);
+        } else {
+            setSelectedChats([]);
+        }
+    }, [existingId, chatOptions]);
 
     return (
         <AlertDialog
@@ -104,7 +142,21 @@ export const AddWebhookDialog = ({
                                 <FormErrorMessage>{eventsError}</FormErrorMessage>
                             ) : null}
                         </FormControl>
-                        
+                        <FormControl mt={5}>
+                            <FormLabel>Chat Filter</FormLabel>
+                            <MultiSelect
+                                size='md'
+                                isMulti={true}
+                                options={chatOptions}
+                                value={selectedChats}
+                                placeholder='All Chats'
+                                onChange={(newValues) => {
+                                    setSelectedChats(newValues as Array<MultiSelectValue>);
+                                }}
+                            />
+                            <FormHelperText>Select specific chats to receive events from. Leave empty for all chats.</FormHelperText>
+                        </FormControl>
+
                     </AlertDialogBody>
 
                     <AlertDialogFooter>
@@ -113,6 +165,7 @@ export const AddWebhookDialog = ({
                             onClick={() => {
                                 if (onCancel) onCancel();
                                 setUrl('');
+                                setSelectedChats([]);
                                 onClose();
                             }}
                         >
@@ -133,13 +186,16 @@ export const AddWebhookDialog = ({
                                     return;
                                 }
 
+                                const chatGuids = selectedChats.length > 0 ? selectedChats.map(c => c.value) : undefined;
+
                                 if (existingId) {
-                                    dispatch(update({ id: existingId, url, events: selectedEvents }));
+                                    dispatch(update({ id: existingId, url, events: selectedEvents, chatGuids: chatGuids ?? null }));
                                 } else {
-                                    dispatch(create({ url, events: selectedEvents }));
+                                    dispatch(create({ url, events: selectedEvents, chatGuids }));
                                 }
 
                                 setUrl('');
+                                setSelectedChats([]);
                                 onClose();
                             }}
                         >

--- a/packages/ui/src/app/components/tables/WebhooksTable.tsx
+++ b/packages/ui/src/app/components/tables/WebhooksTable.tsx
@@ -33,6 +33,7 @@ export const WebhooksTable = ({ webhooks }: { webhooks: Array<WebhookItem> }): J
                     <Tr>
                         <Th>URL</Th>
                         <Th>Event Subscriptions</Th>
+                        <Th>Chat Filter</Th>
                         <Th isNumeric>Actions</Th>
                     </Tr>
                 </Thead>
@@ -41,6 +42,7 @@ export const WebhooksTable = ({ webhooks }: { webhooks: Array<WebhookItem> }): J
                         <Tr key={item.id}>
                             <Td>{item.url}</Td>
                             <Td>{JSON.parse(item.events).map((e: string) => webhookEventValueToLabel(e)).join(', ')}</Td>
+                            <Td>{item.chatGuids && item.chatGuids.length > 0 ? `${item.chatGuids.length} chat(s)` : 'All Chats'}</Td>
                             <Td isNumeric>
                                 <Stack direction="row" justifyContent="end">
                                     <Tooltip label='Edit' placement='bottom'>

--- a/packages/ui/src/app/slices/WebhooksSlice.ts
+++ b/packages/ui/src/app/slices/WebhooksSlice.ts
@@ -8,6 +8,7 @@ export interface WebhookItem {
     id: number;
     url: string;
     events: string;
+    chatGuids: string[] | null;
     created: Date;
 }
 
@@ -29,7 +30,7 @@ export const WebhooksSlice = createSlice({
                 if (!exists) state.webhooks.push(i);
             }
         },
-        create: (state, action: PayloadAction<{ url: string, events: Array<MultiSelectValue> }>) => {
+        create: (state, action: PayloadAction<{ url: string, events: Array<MultiSelectValue>, chatGuids?: Array<string> }>) => {
             const exists = state.webhooks.find(e => e.url === action.payload.url);
             if (exists) {
                 return showErrorToast({
@@ -53,7 +54,7 @@ export const WebhooksSlice = createSlice({
                 });
             });
         },
-        update: (state, action: PayloadAction<{ id: number, url: string, events: Array<MultiSelectValue> }>) => {
+        update: (state, action: PayloadAction<{ id: number, url: string, events: Array<MultiSelectValue>, chatGuids?: Array<string> | null }>) => {
             const existingIndex = state.webhooks.findIndex(e => e.id === action.payload.id);
             if (existingIndex === -1) {
                 return showErrorToast({
@@ -67,13 +68,14 @@ export const WebhooksSlice = createSlice({
             state.webhooks = state.webhooks.map(e => (e.id === action.payload.id) ?
                 { ...e, url: action.payload.url, events: JSON.stringify(action.payload.events.map(i => {
                     return i.value;
-                })) } : e);
+                })), chatGuids: action.payload.chatGuids ?? null } : e);
 
             // Send the update to the backend
             updateWebhook({
                 id: action.payload.id,
                 url: action.payload.url,
-                events: action.payload.events
+                events: action.payload.events,
+                chatGuids: action.payload.chatGuids
             }).then(() => {
                 showSuccessToast({
                     id: 'webhooks',

--- a/packages/ui/src/app/utils/IpcUtils.ts
+++ b/packages/ui/src/app/utils/IpcUtils.ts
@@ -77,7 +77,7 @@ export const getWebhooks = async () => {
     return await ipcRenderer.invoke('get-webhooks');
 };
 
-export const createWebhook = async (payload: { url: string, events: Array<MultiSelectValue> }) => {
+export const createWebhook = async (payload: { url: string, events: Array<MultiSelectValue>, chatGuids?: Array<string> }) => {
     return await ipcRenderer.invoke('create-webhook', payload);
 };
 
@@ -85,8 +85,8 @@ export const deleteWebhook = async ({ url = null, id = null }: { url?: string | 
     return await ipcRenderer.invoke('delete-webhook', { url, id });
 };
 
-export const updateWebhook = async ({ id, url, events }: { id: number, url?: string, events?: Array<MultiSelectValue> }) => {
-    return await ipcRenderer.invoke('update-webhook', { id, url, events });
+export const updateWebhook = async ({ id, url, events, chatGuids }: { id: number, url?: string, events?: Array<MultiSelectValue>, chatGuids?: Array<string> | null }) => {
+    return await ipcRenderer.invoke('update-webhook', { id, url, events, chatGuids });
 };
 
 export const reinstallHelperBundle = async () => {


### PR DESCRIPTION
## Summary

Allow custom webhooks to be configured for each iMessage conversation.

## Context

First of all, this is an excellent project, thank you for building it!

I've been running a few openclaw agents using BlueBubbles with separate iMessage Guids per agent for the communication channel and it has been working flawlessly. However, because all webhook requests go to the same endpoint(s), it makes agent isolation pretty difficult. This change enables users to configure separate webhooks per chat Guid. I would imagine this opens up additional use cases as well.

<img width="621" height="293" alt="image" src="https://github.com/user-attachments/assets/b8146e7f-9e68-429b-8ce9-1c5845cbc825" />

<img width="349" height="457" alt="image" src="https://github.com/user-attachments/assets/98c3f8a4-5727-4ba6-b3ad-ff081c192f38" />

## Test plan

- [x] Create a webhook without selecting any chats - verify it receives all events (existing behavior unchanged)
- [x] Create a webhook scoped to a specific 1:1 chat - verify it only receives events from that chat
- [x] Create a webhook scoped to a group chat - verify filtering works for group events
- [x] Verify chat-filtered webhooks still receive global events (`server-update`, `new-server`)
- [x] Edit an existing webhook to add/remove chat filter - verify changes persist
- [x] Verify the chat dropdown shows readable names (display names for groups, addresses for 1:1)
- [x] Upgrade from a previous version - verify migration adds the column and existing webhooks continue working
- [x] Create a webhook via REST API with `chatGuids` parameter - verify round-trip through GET