### PR TITLE
fix: preserve class names in production builds for TypeORM migrations

### DIFF
--- a/packages/server/scripts/webpack.main.prod.config.js
+++ b/packages/server/scripts/webpack.main.prod.config.js
@@ -1,7 +1,17 @@
 const { merge } = require('webpack-merge');
+const TerserPlugin = require('terser-webpack-plugin');
 
 const baseConfig = require('./webpack.main.config');
 
 module.exports = merge(baseConfig, {
-    mode: 'production'
+    mode: 'production',
+    optimization: {
+        minimizer: [
+            new TerserPlugin({
+                terserOptions: {
+                    keep_classnames: true,
+                },
+            }),
+        ],
+    },
 });


### PR DESCRIPTION
## Summary

Fix a latent bug where TypeORM migrations fail in production builds due to webpack's Terser minification mangling class names.

## Problem

TypeORM's `MigrationExecutor` parses the timestamp from migration class names at runtime (e.g., `WebhookChatGuids1710720000000` → timestamp `1710720000000`). In production builds, webpack's default Terser config minifies class names (e.g., `ei`), causing TypeORM to throw:

```
TypeORMError: ei migration name is wrong. Migration class name should have a JavaScript timestamp appended.
```

The server hangs at "Initializing server database..." and never starts.

## Why it hasn't been noticed

The existing release builds have the same minification behavior, but it doesn't surface because:

1. **Fresh installs**: `config.db` doesn't exist, so `shouldSync = true`, which sets `migrationsRun: false` — TypeORM uses `synchronize: true` instead of running migrations.
2. **Subsequent launches**: The DB already matches the schema, so there are no pending migrations.

The bug only triggers when a **new migration is added** and the app is upgraded on a machine that already has `config.db`.

## Fix

Configure Terser to preserve class names in `webpack.main.prod.config.js`:

```js
new TerserPlugin({
    terserOptions: {
        keep_classnames: true,
    },
})
```

`terser-webpack-plugin` is already available as a transitive dependency of webpack 5 — no new dependencies needed. Bundle size impact is minimal.

## Alternatives considered

- **Scoped `keep_classnames` (migration files only)**: Terser doesn't support per-file class name preservation without a more complex setup
- **`optimization.minimize: false`**: Fixes the issue but disables all minification
- **Setting `name` property on migration classes**: TypeORM checks the class name, not a `name` property, for timestamp parsing
