### PR TITLE
feat: improve contacts permissions UI and add TCC grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ This is the back-end server for the BlueBubbles App. It allows you to forward yo
 4. Run the dev server (this will start both the renderer and server)
     - `npm run start`
 
+### Development Ports
+
+When running the dev server with `npm run start`, the following ports are used:
+
+- **Port 1234** - BlueBubbles API/Socket server (the actual backend that clients connect to)
+- **Port 3000** - React dev server for the Electron app UI (hot-reloading frontend)
+
+The Cloudflare tunnel (if configured) proxies external traffic to `localhost:1234`.
+
 ### macOS Warning
 
 If you are using macOS 10.x and are having issues building/running the server, please downgrade the `node-mac-permissions` dependency to `v2.2.0`. The reason it's on a newer version is to fix a production crashing issue on Big Sur+. Please downgrade it manually for testing on macOS v10.x.

--- a/docs/google-contacts-sync.md
+++ b/docs/google-contacts-sync.md
@@ -1,0 +1,117 @@
+# Google Contacts Sync
+
+BlueBubbles can pull your Google Contacts (names, phone numbers, emails, and
+avatars) into the server's contact database and serve them to connected clients.
+
+There are **two modes**, selected by a toggle on the **Contacts** page of the
+server app:
+
+| Mode | Toggle | What it does | Setup required |
+|------|--------|--------------|----------------|
+| **One‑time import** | OFF (default) | Imports your Google Contacts once, using BlueBubbles' built‑in Google sign‑in. | **None** — just click *Continue with Google*. |
+| **Background sync** | ON | Keeps contacts in sync automatically on an interval (adds/updates/deletes). | Your **own** Google OAuth client (this guide). |
+
+> **Why your own client for background sync?** Background sync needs *offline*
+> access (a long‑lived **refresh token**). Google only issues refresh tokens
+> through the authorization‑code flow, which requires a **client secret**. The
+> built‑in BlueBubbles client is a public/secret‑less client, so it can't grant
+> offline access — hence the one‑time import is the most it can do. Using your
+> own OAuth client gives you a secret you control, which unlocks background sync.
+
+---
+
+## Setting up your own Google OAuth client (background sync)
+
+This takes ~5 minutes in the [Google Cloud Console](https://console.cloud.google.com).
+
+### 1. Create or select a project
+- Top bar → project picker → **New Project** (or reuse an existing one).
+
+### 2. Enable the People API
+- **APIs & Services → Library** → search **"People API"** → **Enable**.
+
+### 3. Configure the OAuth consent screen
+- **APIs & Services → OAuth consent screen**.
+- **User type: External** → Create.
+- Fill in the required fields (app name, your email).
+- **Scopes:** add `https://www.googleapis.com/auth/contacts.readonly`.
+- **Test users:** add the Google account you'll sign in with.
+- ⚠️ **Important — publishing status & the 7‑day token expiry:**
+  While the app is in **"Testing"**, Google **expires refresh tokens after 7
+  days**, which will silently break background sync once a week. To get a
+  non‑expiring token, set the publishing status to **"In production"**
+  (**OAuth consent screen → Publish app**). For personal use you can ignore the
+  "unverified app" warning — `contacts.readonly` is a sensitive scope, but
+  unverified production apps still work for a small number of users; you'll just
+  see a one‑time warning during sign‑in. (Verification is only needed to remove
+  the warning / support many users.)
+
+### 4. Create the OAuth client ID
+- **APIs & Services → Credentials → Create Credentials → OAuth client ID**.
+- **Application type: Desktop app** (recommended — it gets a client secret and
+  automatically allows the loopback redirect, so there's nothing else to
+  configure).
+- Click **Create**, then copy the **Client ID** and **Client secret**.
+
+> **Using a "Web application" client instead?** It also works, but you must add
+> this exact **Authorized redirect URI**:
+> `http://localhost:8641/oauth/callback`
+> Desktop‑app clients don't need this — loopback redirects are allowed by default.
+
+### 5. Connect it in BlueBubbles
+1. Open the **BlueBubbles Server** app → **Contacts** page.
+2. Turn **ON** the toggle **"Use my own Google OAuth client (enables automatic
+   background sync)"**.
+3. Under **Step 1**, paste your **Client ID** and **Client secret** → **Save**.
+4. Under **Step 2**, click **Continue with Google**, sign in with your **test‑user**
+   account, and grant access.
+5. On success the status shows **Synced** and the background controls appear:
+   - **Keep contacts synced in the background** — enable/disable the scheduler.
+   - **Sync every N minutes** — how often to sync (default 360 = 6 hours).
+   - **Sync Now** — run a sync immediately.
+   - **Disconnect** — revoke and clear the stored token, and stop syncing.
+
+---
+
+## How it works
+
+- The first sync is a **full** sync; subsequent syncs are **incremental** using
+  the People API *sync token*, so only changes (including deletions) are applied.
+- Contacts are matched by their Google `resourceName` (stored as `externalId`).
+  Existing contacts from a previous one‑time import are matched by name and have
+  their `externalId` back‑filled, so they aren't duplicated.
+- Google's generic silhouette avatars are skipped (only real photos are saved).
+- The scheduler runs on the configured interval and also does a catch‑up sync on
+  server startup if it's overdue.
+
+## Configuration keys
+
+Stored in the server config (set automatically via the UI; listed for reference):
+
+| Key | Meaning |
+|-----|---------|
+| `google_contacts_use_own_client` | `0` = one‑time mode, `1` = background mode |
+| `google_oauth_client_id` | Your OAuth client ID (background mode) |
+| `google_oauth_client_secret` | Your OAuth client secret (background mode) |
+| `google_contacts_sync_enabled` | Whether the background scheduler is on |
+| `google_contacts_sync_interval` | Minutes between syncs (default 360) |
+| `google_contacts_refresh_token` | Stored offline token (managed automatically) |
+| `google_contacts_sync_token` | People API incremental sync token (managed automatically) |
+| `google_contacts_last_sync` | Timestamp of the last successful sync |
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| **"client_secret is missing"** | You're connecting with the built‑in client (one‑time toggle OFF) but the server tried the offline flow, **or** the secret wasn't saved. Make sure the toggle is ON and you saved a valid Client **ID + secret**. |
+| **"access_denied" / "app is being tested"** | Add your Google account as a **test user** on the OAuth consent screen. |
+| **Sync worked, then stopped after ~a week** | Your app is still in **"Testing"** — refresh tokens expire after 7 days. Set the consent screen to **"In production"**, then **Disconnect** and **Continue with Google** again. |
+| **"invalid_grant" in the logs** | The refresh token was revoked/expired. Reconnect via **Continue with Google**. |
+| **People API errors** | Make sure the **People API** is enabled in the same project as your OAuth client. |
+
+## Privacy & security
+
+- The scope requested is **read‑only** (`contacts.readonly`).
+- Your client secret and refresh token are stored in the server's local config
+  database (the same place other server secrets live). Use **Disconnect** to
+  revoke and remove the token at any time.

--- a/packages/server/src/server/api/interfaces/chatInterface.ts
+++ b/packages/server/src/server/api/interfaces/chatInterface.ts
@@ -31,18 +31,16 @@ export class ChatInterface {
         limit = null,
         sort = "lastmessage"
     }: any = {}): Promise<[ChatResponse[], number]> {
-        // First fetch chats without the last message.
-        // This is because fetching the last message will make the participants list 1 for each chat.
-        // It will also only return chats that have a last message.
-        const [chats, totalChats] = await Server().iMessageRepo.getChats({
-            chatGuid: guid as string,
-            withLastMessage: false,
-            withArchived,
-            offset,
-            limit
-        });
+        const sortByLastMessage = sort === "lastmessage" && withLastMessage;
 
+        // Build a cache of each chat's last message. When sorting by last
+        // message we also use it to order ALL chats by recency *before*
+        // paginating. Previously offset/limit were applied in DB (ROWID) order
+        // and only the resulting page was sorted, so the most-recent chats were
+        // not guaranteed to be in the first page (e.g. a staged/paginated client
+        // would show stale chats first).
         const lastMessageCache: { [key: string]: Message | null } = {};
+        let orderedGuids: string[] | null = null;
         if (withLastMessage) {
             const [tmpChats, _] = await Server().iMessageRepo.getChats({
                 chatGuid: guid as string,
@@ -56,6 +54,77 @@ export class ChatInterface {
             for (const chat of tmpChats) {
                 lastMessageCache[chat.guid] = chat.messages.length > 0 ? chat.messages[0] : null;
             }
+
+            if (sortByLastMessage) {
+                // Order ALL chats by recency. A higher last-message ROWID means a
+                // more recent message; chats with no messages have no cached
+                // message and sort last. We fetch the full guid list separately
+                // (the withLastMessage query only returns chats that have a
+                // message) so message-less chats are still included, matching the
+                // previous behaviour.
+                const [allChats] = await Server().iMessageRepo.getChats({
+                    chatGuid: guid as string,
+                    withLastMessage: false,
+                    withParticipants: false,
+                    withArchived,
+                    offset: null,
+                    limit: null
+                });
+                orderedGuids = allChats
+                    .map((c: Chat) => c.guid)
+                    .sort((a: string, b: string) => (lastMessageCache[b]?.ROWID ?? 0) - (lastMessageCache[a]?.ROWID ?? 0));
+            }
+        }
+
+        // Fetch the page of chats (with participants) we actually need to return.
+        // We fetch participants separately from the last message because joining
+        // the last message collapses the participants list to one per chat.
+        let chats: Chat[];
+        let totalChats: number;
+        if (sortByLastMessage && orderedGuids) {
+            totalChats = orderedGuids.length;
+            const start = offset ?? 0;
+            const end = limit != null ? start + limit : orderedGuids.length;
+            const pageGuids = orderedGuids.slice(start, end);
+
+            if (isEmpty(pageGuids)) {
+                chats = [];
+            } else {
+                // For the common (paginated) case, fetch just this page via an IN
+                // filter. Fall back to fetching everything if the page is large
+                // enough to risk SQLite's bound-variable limit.
+                let pageChats: Chat[];
+                if (pageGuids.length <= 900) {
+                    [pageChats] = await Server().iMessageRepo.getChats({
+                        chatGuid: guid as string,
+                        withLastMessage: false,
+                        withArchived,
+                        offset: null,
+                        limit: null,
+                        where: [{ statement: "chat.guid IN (:...guids)", args: { guids: pageGuids } }]
+                    });
+                } else {
+                    [pageChats] = await Server().iMessageRepo.getChats({
+                        chatGuid: guid as string,
+                        withLastMessage: false,
+                        withArchived,
+                        offset: null,
+                        limit: null
+                    });
+                }
+
+                // SQL `IN` doesn't preserve order, so re-apply the recency order.
+                const byGuid = new Map<string, Chat>(pageChats.map((c: Chat) => [c.guid, c]));
+                chats = pageGuids.map((g: string) => byGuid.get(g)).filter((c): c is Chat => !!c);
+            }
+        } else {
+            [chats, totalChats] = await Server().iMessageRepo.getChats({
+                chatGuid: guid as string,
+                withLastMessage: false,
+                withArchived,
+                offset,
+                limit
+            });
         }
 
         const results = [];

--- a/packages/server/src/server/api/interfaces/contactInterface.ts
+++ b/packages/server/src/server/api/interfaces/contactInterface.ts
@@ -103,12 +103,14 @@ export class ContactInterface {
      * @param preloadedContacts If you already loaded a list of contacts, pass it here
      * @returns A contact entry dictionary
      */
-    static findContact(address: string, { preloadedContacts }: { preloadedContacts?: any[] | null } = {}): any | null {
-        const contactList = preloadedContacts ?? ContactsLib.getAllContacts();
+    /**
+     * Build a map of stripped-address -> contact from a contact list. Build this
+     * ONCE and pass it to [findContact] via `preloadedCacheMap` when looking up
+     * many addresses, so the map isn't rebuilt on every lookup (which made
+     * queryContacts O(addresses * contacts)).
+     */
+    static buildContactAddressMap(contactList: any[]): NodeJS.Dict<any> {
         const alphaNumericRegex = /[^a-zA-Z0-9_]/gi;
-        const addr = address.replace(alphaNumericRegex, "");
-
-        // Build a map where the address is the key and contact dict is the value
         const cacheMap: NodeJS.Dict<any> = {};
         for (const c of contactList) {
             const addresses = [
@@ -120,6 +122,24 @@ export class ContactInterface {
             }
         }
 
+        return cacheMap;
+    }
+
+    static findContact(
+        address: string,
+        { preloadedContacts, preloadedCacheMap }:
+            { preloadedContacts?: any[] | null; preloadedCacheMap?: NodeJS.Dict<any> | null } = {}
+    ): any | null {
+        const alphaNumericRegex = /[^a-zA-Z0-9_]/gi;
+        const addr = address.replace(alphaNumericRegex, "");
+
+        // Use the prebuilt address -> contact map when provided (the fast path
+        // for bulk lookups); otherwise build one from the contact list.
+        const cacheMap =
+            preloadedCacheMap ??
+            ContactInterface.buildContactAddressMap(preloadedContacts ?? ContactsLib.getAllContacts());
+        const keys = Object.keys(cacheMap);
+
         // Find a key that matches the last 'x' characters.
         // First, test the entire string, then slowly remove numbers from the start
         // until we find a match. If we don't find a match after testing 4 varients, we are done.
@@ -127,9 +147,9 @@ export class ContactInterface {
         let output: NodeJS.Dict<any> = null;
         for (const sub of choices) {
             const ending = addr.substring(addr.length - sub, addr.length);
-            const matches = Object.keys(cacheMap).filter(e => e && e.endsWith(ending));
-            if (matches && matches.length > 0) {
-                output = cacheMap[matches[0]];
+            const match = keys.find(e => e && e.endsWith(ending));
+            if (match) {
+                output = cacheMap[match];
                 break;
             }
         }
@@ -475,9 +495,15 @@ export class ContactInterface {
         const data: any[] = [];
 
         const contactList = await ContactInterface.getAllContacts(extraProperties);
+        // Build the address -> contact map once and reuse it for every address
+        // (was rebuilt per address — O(addresses * contacts)). Dedupe results so
+        // a contact matched by several of its addresses is only returned once.
+        const cacheMap = ContactInterface.buildContactAddressMap(contactList);
+        const seen = new Set<any>();
         for (const i of addresses) {
-            const found = ContactInterface.findContact(i, { preloadedContacts: contactList });
-            if (found) {
+            const found = ContactInterface.findContact(i, { preloadedCacheMap: cacheMap });
+            if (found && !seen.has(found)) {
+                seen.add(found);
                 data.push(found);
             }
         }

--- a/packages/server/src/server/databases/imessage/types.ts
+++ b/packages/server/src/server/databases/imessage/types.ts
@@ -15,7 +15,8 @@ export type DBMessageParams = {
 
 export type DBWhereItem = {
     statement: string;
-    args: { [key: string]: string | number };
+    // Arrays are supported for `IN (:...param)` style clauses.
+    args: { [key: string]: string | number | (string | number)[] };
 };
 
 export type ChatParams = {

--- a/packages/server/src/server/databases/server/constants.ts
+++ b/packages/server/src/server/databases/server/constants.ts
@@ -56,4 +56,25 @@ export const DEFAULT_DB_ITEMS: { [key: string]: () => any } = {
     landing_page_path: () => "",
     open_findmy_on_startup: () => 1,
     auto_lock_mac: () => 0,
+    // Google Contacts background sync.
+    // Selects the Google flow: 0 = one-time import using the built-in client
+    // (implicit flow, no setup); 1 = use the user's own OAuth client for
+    // offline/background sync (approach "B").
+    google_contacts_use_own_client: () => 0,
+    // Opt-in: disabled by default. When enabled, the server keeps the local
+    // contact database in sync with the user's Google Contacts on an interval.
+    google_contacts_sync_enabled: () => 0,
+    // Minutes between background syncs (default: 6 hours).
+    google_contacts_sync_interval: () => 360,
+    // The OAuth refresh token used for offline/background access. Empty until
+    // the user authorizes with offline access (authorization-code + PKCE flow).
+    google_contacts_refresh_token: () => "",
+    // The People API sync token, used to fetch only changes since the last sync.
+    google_contacts_sync_token: () => "",
+    // Timestamp (ms) of the last successful Google Contacts sync.
+    google_contacts_last_sync: () => 0,
+    // Optional user-provided OAuth client (approach B). When both are set, they
+    // override the built-in shared client. Leave empty to use the built-in one.
+    google_oauth_client_id: () => "",
+    google_oauth_client_secret: () => "",
 };

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -31,6 +31,7 @@ import {
     WebhookService,
     ScheduledMessagesService,
     OauthService,
+    GoogleContactsService,
     ZrokService
 } from "@server/services";
 import { EventCache } from "@server/eventCache";
@@ -148,6 +149,8 @@ class BlueBubblesServer extends EventEmitter {
 
     oauthService: OauthService;
 
+    googleContactsService: GoogleContactsService;
+
     actionHandler: ActionHandler;
 
     eventCache: EventCache;
@@ -235,6 +238,7 @@ class BlueBubblesServer extends EventEmitter {
         this.webhookService = null;
         this.scheduledMessages = null;
         this.oauthService = null;
+        this.googleContactsService = null;
         this.iMessageListener = null;
 
         this.hasSetup = false;
@@ -451,6 +455,13 @@ class BlueBubblesServer extends EventEmitter {
         } catch (ex: any) {
             this.logger.error(`Failed to setup OAuth service! ${ex?.message ?? String(ex)}}`);
         }
+
+        try {
+            this.logger.info("Initializing Google Contacts service...");
+            this.googleContactsService = new GoogleContactsService();
+        } catch (ex: any) {
+            this.logger.error(`Failed to setup Google Contacts service! ${ex?.message ?? String(ex)}}`);
+        }
     }
 
     async initServices(): Promise<void> {
@@ -545,6 +556,12 @@ class BlueBubblesServer extends EventEmitter {
             this.logger.error(`Failed to start Scheduled Messages service! ${ex?.message ?? String(ex)}}`);
         }
 
+        try {
+            await this.googleContactsService?.start();
+        } catch (ex: any) {
+            this.logger.error(`Failed to start Google Contacts sync! ${ex?.message ?? String(ex)}}`);
+        }
+
         const privateApiEnabled = this.repo.getConfig("enable_private_api") as boolean;
         const ftPrivateApiEnabled = this.repo.getConfig("enable_ft_private_api") as boolean;
         if (privateApiEnabled || ftPrivateApiEnabled) {
@@ -604,6 +621,12 @@ class BlueBubblesServer extends EventEmitter {
             await this.oauthService?.stop();
         } catch (ex: any) {
             this.logger.error(`Failed to stop OAuth service! ${ex?.message ?? ex}`);
+        }
+
+        try {
+            await this.googleContactsService?.stop();
+        } catch (ex: any) {
+            this.logger.error(`Failed to stop Google Contacts service! ${ex?.message ?? ex}`);
         }
 
         try {

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -42,7 +42,7 @@ import { isMinBigSur, isMinCatalina, isMinHighSierra, isMinMojave, isMinMonterey
 import { Proxy } from "./services/proxyServices/proxy";
 import { PrivateApiService } from "./api/privateApi/PrivateApiService";
 import { OutgoingMessageManager } from "./managers/outgoingMessageManager";
-import { requestContactPermission } from "./utils/PermissionUtils";
+import { getContactPermissionStatus, requestContactPermission } from "./utils/PermissionUtils";
 import { AlertsInterface } from "./api/interfaces/alertsInterface";
 import { MessageSerializer } from "./api/serializers/MessageSerializer";
 import {
@@ -1250,18 +1250,30 @@ class BlueBubblesServer extends EventEmitter {
     }
 
     async checkPermissions(): Promise<Array<NodeJS.Dict<any>>> {
+        const isDev = process.env.NODE_ENV !== "production";
+        const appName = isDev ? "Electron" : "BlueBubbles";
+        const contactStatus = getContactPermissionStatus();
+
         const output = [
             {
                 name: "Accessibility (Optional)",
                 pass: systemPreferences.isTrustedAccessibilityClient(false),
-                solution: "Open System Preferences > Security > Privacy > Accessibility, then add BlueBubbles"
+                solution: `Open System Preferences > Security > Privacy > Accessibility, then add ${appName}`
             },
             {
                 name: "Full Disk Access",
                 pass: this.hasDiskAccess,
                 solution:
-                    "Open System Preferences > Security > Privacy > Full Disk Access, " +
-                    "then add BlueBubbles. Lastly, restart BlueBubbles."
+                    `Open System Preferences > Security > Privacy > Full Disk Access, ` +
+                    `then add ${appName}. Lastly, restart BlueBubbles.`
+            },
+            {
+                name: "Contacts (Optional)",
+                pass: contactStatus === "Authorized",
+                solution: isDev
+                    ? "Open System Preferences > Security > Privacy > Contacts, then add Electron.app " +
+                      "from: ~/Developer/bluebubbles/bluebubbles-server/node_modules/electron/dist/"
+                    : "Open System Preferences > Security > Privacy > Contacts, then add BlueBubbles"
             }
         ];
 

--- a/packages/server/src/server/services/googleContactsService/index.ts
+++ b/packages/server/src/server/services/googleContactsService/index.ts
@@ -1,0 +1,445 @@
+import axios from "axios";
+import { google, Auth, people_v1 } from "googleapis";
+import { Server } from "@server";
+import { Loggable } from "@server/lib/logging/Loggable";
+import { ContactInterface } from "@server/api/interfaces/contactInterface";
+import { Contact } from "@server/databases/server/entity/Contact";
+import { isEmpty, isNotEmpty } from "@server/helpers/utils";
+
+/**
+ * The built-in, shared BlueBubbles OAuth client. This is a public client with
+ * no secret. Whether Google will issue a refresh token for it via the
+ * authorization-code + PKCE flow (approach "A") is determined at runtime; if it
+ * does not, the user can provide their own OAuth client (approach "B") by
+ * setting `google_oauth_client_id` / `google_oauth_client_secret` in config.
+ */
+export const BUILTIN_GOOGLE_CLIENT_ID =
+    "500464701389-os4g4b8mfoj86vujg4i61dmh9827qbrv.apps.googleusercontent.com";
+
+/** The loopback redirect URI used for the interactive OAuth consent. */
+export const GOOGLE_OAUTH_REDIRECT_URI = "http://localhost:8641/oauth/callback";
+
+/** The person fields we request from the People API. */
+export const GOOGLE_CONTACTS_PERSON_FIELDS = "names,emailAddresses,phoneNumbers,nicknames,photos";
+
+export interface GoogleOAuthClientConfig {
+    clientId: string;
+    clientSecret: string | null;
+}
+
+/**
+ * Resolves which OAuth client to use. If the user has provided their own client
+ * (approach "B"), that takes precedence; otherwise we fall back to the built-in
+ * shared client (approach "A").
+ */
+export const resolveGoogleOAuthClientConfig = (): GoogleOAuthClientConfig => {
+    const cfgId = (Server().repo?.getConfig("google_oauth_client_id") as string) ?? "";
+    const cfgSecret = (Server().repo?.getConfig("google_oauth_client_secret") as string) ?? "";
+    if (isNotEmpty(cfgId)) {
+        return { clientId: cfgId, clientSecret: isNotEmpty(cfgSecret) ? cfgSecret : null };
+    }
+
+    return { clientId: BUILTIN_GOOGLE_CLIENT_ID, clientSecret: null };
+};
+
+export interface GoogleContactsSyncStats {
+    added: number;
+    updated: number;
+    deleted: number;
+}
+
+export interface GoogleContactsStatus {
+    enabled: boolean;
+    connected: boolean;
+    syncing: boolean;
+    interval: number;
+    lastSync: number;
+    usingCustomClient: boolean;
+}
+
+/**
+ * Keeps the local contact database in sync with the user's Google Contacts.
+ *
+ * - Holds an OAuth2 client seeded with a stored refresh token (offline access),
+ *   so it can fetch contacts in the background without further user interaction.
+ * - Performs incremental syncs using the People API sync token, applying both
+ *   upserts and deletions, keyed on `externalId` (the Google `resourceName`).
+ * - Owns the periodic scheduler.
+ */
+export class GoogleContactsService extends Loggable {
+    tag = "GoogleContactsService";
+
+    private oauthClient: Auth.OAuth2Client | null = null;
+
+    private syncTimer: NodeJS.Timeout | null = null;
+
+    private syncing = false;
+
+    // ---------------------------------------------------------------------
+    // Config-backed accessors
+    // ---------------------------------------------------------------------
+
+    get enabled(): boolean {
+        return (Server().repo?.getConfig("google_contacts_sync_enabled") as boolean) ?? false;
+    }
+
+    get intervalMinutes(): number {
+        const value = Number(Server().repo?.getConfig("google_contacts_sync_interval") ?? 360);
+        return Number.isFinite(value) && value > 0 ? value : 360;
+    }
+
+    get refreshToken(): string {
+        return (Server().repo?.getConfig("google_contacts_refresh_token") as string) ?? "";
+    }
+
+    get syncToken(): string {
+        return (Server().repo?.getConfig("google_contacts_sync_token") as string) ?? "";
+    }
+
+    get lastSync(): number {
+        return Number(Server().repo?.getConfig("google_contacts_last_sync") ?? 0);
+    }
+
+    get isConnected(): boolean {
+        return isNotEmpty(this.refreshToken);
+    }
+
+    getStatus(): GoogleContactsStatus {
+        return {
+            enabled: this.enabled,
+            connected: this.isConnected,
+            syncing: this.syncing,
+            interval: this.intervalMinutes,
+            lastSync: this.lastSync,
+            usingCustomClient: isNotEmpty(Server().repo?.getConfig("google_oauth_client_id") as string)
+        };
+    }
+
+    // ---------------------------------------------------------------------
+    // OAuth client
+    // ---------------------------------------------------------------------
+
+    private buildClient(): Auth.OAuth2Client | null {
+        if (isEmpty(this.refreshToken)) return null;
+
+        const { clientId, clientSecret } = resolveGoogleOAuthClientConfig();
+        const client = new google.auth.OAuth2(clientId, clientSecret ?? undefined, GOOGLE_OAUTH_REDIRECT_URI);
+        client.setCredentials({ refresh_token: this.refreshToken });
+
+        // Persist a rotated refresh token if Google ever issues a new one.
+        client.on("tokens", async (tokens: Auth.Credentials) => {
+            if (tokens.refresh_token) {
+                try {
+                    await Server().repo.setConfig("google_contacts_refresh_token", tokens.refresh_token);
+                } catch (ex: any) {
+                    this.log.debug(`Failed to persist rotated refresh token: ${ex?.message ?? String(ex)}`);
+                }
+            }
+        });
+
+        this.oauthClient = client;
+        return client;
+    }
+
+    // ---------------------------------------------------------------------
+    // Lifecycle / scheduling
+    // ---------------------------------------------------------------------
+
+    /** Called once on server startup. Schedules background sync if enabled & connected. */
+    async start(): Promise<void> {
+        if (!this.enabled) {
+            this.log.debug("Background sync is disabled; not scheduling.");
+            return;
+        }
+
+        if (!this.isConnected) {
+            this.log.debug("Background sync is enabled but not connected (no refresh token).");
+            return;
+        }
+
+        this.scheduleTimer();
+
+        // Catch-up sync if we've never synced or we're overdue.
+        const due = this.lastSync === 0 || Date.now() - this.lastSync >= this.intervalMinutes * 60_000;
+        if (due) {
+            this.sync().catch(ex => this.log.error(`Startup sync failed: ${this.describeError(ex)}`));
+        }
+    }
+
+    private scheduleTimer(): void {
+        this.clearTimer();
+        const period = this.intervalMinutes * 60_000;
+        this.syncTimer = setInterval(() => {
+            this.sync().catch(ex => this.log.error(`Scheduled sync failed: ${this.describeError(ex)}`));
+        }, period);
+        this.log.info(`Scheduled Google Contacts sync every ${this.intervalMinutes} minute(s).`);
+    }
+
+    private clearTimer(): void {
+        if (this.syncTimer) {
+            clearInterval(this.syncTimer);
+            this.syncTimer = null;
+        }
+    }
+
+    /** Re-applies scheduling after an enable/interval change. */
+    async restart(): Promise<void> {
+        this.clearTimer();
+        await this.start();
+    }
+
+    async stop(): Promise<void> {
+        this.clearTimer();
+    }
+
+    async setEnabled(enabled: boolean): Promise<void> {
+        await Server().repo.setConfig("google_contacts_sync_enabled", enabled);
+        await this.restart();
+    }
+
+    async setSyncInterval(minutes: number): Promise<void> {
+        await Server().repo.setConfig("google_contacts_sync_interval", minutes);
+        await this.restart();
+    }
+
+    // ---------------------------------------------------------------------
+    // Connect / disconnect
+    // ---------------------------------------------------------------------
+
+    /**
+     * Called after a successful interactive consent that yielded a refresh token.
+     * Stores the token, enables sync, and performs an immediate full sync.
+     */
+    async connectWithRefreshToken(refreshToken: string): Promise<void> {
+        await Server().repo.setConfig("google_contacts_refresh_token", refreshToken);
+        // New connection → reset the sync token to force a full sync.
+        await Server().repo.setConfig("google_contacts_sync_token", "");
+        await Server().repo.setConfig("google_contacts_sync_enabled", true);
+
+        this.buildClient();
+        this.scheduleTimer();
+
+        await this.syncNow(true);
+    }
+
+    /** Revokes & clears stored tokens and stops scheduling. */
+    async disconnect(): Promise<void> {
+        this.clearTimer();
+
+        try {
+            const client = this.oauthClient ?? this.buildClient();
+            if (client && isNotEmpty(this.refreshToken)) {
+                await client.revokeToken(this.refreshToken);
+            }
+        } catch (ex: any) {
+            this.log.debug(`Failed to revoke Google token: ${ex?.message ?? String(ex)}`);
+        }
+
+        this.oauthClient = null;
+        await Server().repo.setConfig("google_contacts_refresh_token", "");
+        await Server().repo.setConfig("google_contacts_sync_token", "");
+        await Server().repo.setConfig("google_contacts_sync_enabled", false);
+        this.log.info("Disconnected Google Contacts sync.");
+    }
+
+    // ---------------------------------------------------------------------
+    // Sync
+    // ---------------------------------------------------------------------
+
+    async syncNow(force = false): Promise<GoogleContactsSyncStats> {
+        return await this.sync(force);
+    }
+
+    private async sync(_force = false): Promise<GoogleContactsSyncStats> {
+        if (this.syncing) {
+            this.log.debug("A sync is already in progress; skipping.");
+            return { added: 0, updated: 0, deleted: 0 };
+        }
+
+        if (!this.isConnected) {
+            throw new Error("Google Contacts is not connected (no refresh token).");
+        }
+
+        this.syncing = true;
+        const client = this.oauthClient ?? this.buildClient();
+        const people = google.people({ version: "v1", auth: client });
+        const stats: GoogleContactsSyncStats = { added: 0, updated: 0, deleted: 0 };
+
+        try {
+            let nextSyncToken: string | undefined;
+
+            const runPass = async (withSyncToken: boolean): Promise<void> => {
+                let pageToken: string | undefined;
+                do {
+                    const res = await people.people.connections.list({
+                        resourceName: "people/me",
+                        personFields: GOOGLE_CONTACTS_PERSON_FIELDS,
+                        pageSize: 1000,
+                        pageToken,
+                        requestSyncToken: true,
+                        syncToken: withSyncToken ? this.syncToken : undefined
+                    });
+
+                    const connections = res.data.connections ?? [];
+                    for (const person of connections) {
+                        if (person.metadata?.deleted) {
+                            if (await this.deletePerson(person)) stats.deleted += 1;
+                        } else {
+                            const result = await this.upsertPerson(person);
+                            if (result === "added") stats.added += 1;
+                            else if (result === "updated") stats.updated += 1;
+                        }
+                    }
+
+                    pageToken = res.data.nextPageToken ?? undefined;
+                    nextSyncToken = res.data.nextSyncToken ?? nextSyncToken;
+                } while (pageToken);
+            };
+
+            const useSyncToken = isNotEmpty(this.syncToken);
+            try {
+                this.log.info(
+                    useSyncToken
+                        ? "Performing incremental Google Contacts sync..."
+                        : "Performing full Google Contacts sync..."
+                );
+                await runPass(useSyncToken);
+            } catch (ex: any) {
+                // An expired sync token returns HTTP 410 (GONE). Reset & full resync.
+                const code = ex?.code ?? ex?.response?.status;
+                if (code === 410 || code === "410") {
+                    this.log.info("Google sync token expired; performing a full resync.");
+                    await Server().repo.setConfig("google_contacts_sync_token", "");
+                    nextSyncToken = undefined;
+                    await runPass(false);
+                } else {
+                    this.log.error(`Google Contacts sync failed: ${this.describeError(ex)}`);
+                    throw ex;
+                }
+            }
+
+            if (isNotEmpty(nextSyncToken)) {
+                await Server().repo.setConfig("google_contacts_sync_token", nextSyncToken);
+            }
+            await Server().repo.setConfig("google_contacts_last_sync", Date.now());
+
+            this.log.info(
+                `Google Contacts sync complete. Added ${stats.added}, updated ${stats.updated}, ` +
+                    `deleted ${stats.deleted}.`
+            );
+            return stats;
+        } finally {
+            this.syncing = false;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-person helpers
+    // ---------------------------------------------------------------------
+
+    private async upsertPerson(person: people_v1.Schema$Person): Promise<"added" | "updated" | "skipped"> {
+        if (isEmpty(person.names)) return "skipped";
+
+        const externalId = person.resourceName ?? undefined;
+        const name = person.names[0];
+        const firstName = name.givenName ?? "";
+        const lastName = name.familyName ?? "";
+        const displayName = name.displayName ?? "";
+        const phoneNumbers = (person.phoneNumbers ?? [])
+            .map((p: any) => p.canonicalForm ?? p.value)
+            .filter((p: any) => isNotEmpty(p));
+        const emails = (person.emailAddresses ?? []).map((e: any) => e.value).filter((e: any) => isNotEmpty(e));
+        const avatar = await this.loadAvatar(person);
+
+        // Find by externalId; if not found (e.g. contacts created by the older
+        // name-based sync), fall back to a name match and backfill the externalId.
+        let existing: Contact | null = null;
+        if (isNotEmpty(externalId)) {
+            existing = await ContactInterface.findDbContact({ externalId, throwError: false });
+        }
+        if (!existing) {
+            existing = await this.findByName(firstName, lastName, displayName);
+        }
+
+        try {
+            await ContactInterface.createOrUpdateContact({
+                id: existing?.id,
+                externalId,
+                firstName,
+                lastName,
+                displayName,
+                phoneNumbers,
+                emails,
+                avatar: avatar ?? null,
+                updateEntry: true
+            });
+            return existing ? "updated" : "added";
+        } catch (ex: any) {
+            this.log.debug(`Failed to upsert contact "${displayName || firstName}": ${ex?.message ?? String(ex)}`);
+            return "skipped";
+        }
+    }
+
+    private async deletePerson(person: people_v1.Schema$Person): Promise<boolean> {
+        const externalId = person.resourceName ?? undefined;
+        if (isEmpty(externalId)) return false;
+
+        try {
+            await ContactInterface.deleteContact({ externalId });
+            return true;
+        } catch {
+            // The contact may not exist locally; ignore.
+            return false;
+        }
+    }
+
+    private async findByName(firstName: string, lastName: string, displayName: string): Promise<Contact | null> {
+        if (isEmpty(firstName) && isEmpty(lastName) && isEmpty(displayName)) return null;
+
+        const where: Record<string, string> = {};
+        if (isNotEmpty(firstName)) where.firstName = firstName;
+        if (isNotEmpty(lastName)) where.lastName = lastName;
+        if (isNotEmpty(displayName)) where.displayName = displayName;
+
+        return await Server()
+            .repo.contacts()
+            .findOne({ where, relations: { addresses: true } });
+    }
+
+    /** Extracts a human-readable message from a googleapis / Gaxios error. */
+    private describeError(ex: any): string {
+        return (
+            ex?.response?.data?.error?.message ??
+            ex?.response?.data?.error_description ??
+            (typeof ex?.response?.data?.error === "string" ? ex.response.data.error : null) ??
+            ex?.errors?.[0]?.message ??
+            ex?.message ??
+            String(ex)
+        );
+    }
+
+    private async loadAvatar(person: people_v1.Schema$Person): Promise<Buffer | null> {
+        const photos = (person.photos ?? []) as any[];
+        // Skip Google's generic silhouette/default photos.
+        const usable = photos.filter(p => !p.default);
+
+        let photoUrl: string | null = null;
+        const primary = usable.find(p => p.metadata?.primary);
+        if (primary) {
+            photoUrl = primary.url;
+        } else if (isNotEmpty(usable)) {
+            photoUrl = usable[0].url;
+        }
+
+        if (isEmpty(photoUrl)) return null;
+
+        // Request a larger image than the default 100px.
+        photoUrl = photoUrl.replace("s100", "s240-p-k-rw-no");
+        try {
+            const res = await axios.get(photoUrl, { responseType: "arraybuffer" });
+            return res?.data ?? null;
+        } catch {
+            return null;
+        }
+    }
+}

--- a/packages/server/src/server/services/index.ts
+++ b/packages/server/src/server/services/index.ts
@@ -11,6 +11,7 @@ import { CertificateService } from "./certificateService";
 import { WebhookService } from "./webhookService";
 import { ScheduledMessagesService } from "./scheduledMessagesService";
 import { OauthService } from "./oauthService";
+import { GoogleContactsService } from "./googleContactsService";
 
 export {
     FCMService,
@@ -25,5 +26,6 @@ export {
     CloudflareService,
     WebhookService,
     ScheduledMessagesService,
-    OauthService
+    OauthService,
+    GoogleContactsService
 };

--- a/packages/server/src/server/services/ipcService/index.ts
+++ b/packages/server/src/server/services/ipcService/index.ts
@@ -1,5 +1,5 @@
 import { app, dialog, ipcMain, systemPreferences, shell } from "electron";
-import { askForAccessibilityAccess, askForFullDiskAccess } from "node-mac-permissions";
+import { askForAccessibilityAccess, askForFullDiskAccess, askForContactsAccess } from "node-mac-permissions";
 import process from "process";
 
 import { Server } from "@server";
@@ -9,7 +9,7 @@ import { openLogs, openAppData } from "@server/api/apple/scripts";
 import { fixServerUrl } from "@server/helpers/utils";
 import { ContactInterface } from "@server/api/interfaces/contactInterface";
 import { PrivateApiService } from "../../api/privateApi/PrivateApiService";
-import { getContactPermissionStatus, requestContactPermission } from "@server/utils/PermissionUtils";
+import { getContactPermissionStatus, requestContactPermission, grantContactsViaTCC } from "@server/utils/PermissionUtils";
 import { ScheduledMessagesInterface } from "@server/api/interfaces/scheduledMessagesInterface";
 import { ChatInterface } from "@server/api/interfaces/chatInterface";
 import { GeneralInterface } from "@server/api/interfaces/generalInterface";
@@ -172,7 +172,21 @@ export class IPCService extends Loggable {
         });
 
         ipcMain.handle("request-contact-permission", async (event, force) => {
-            return await requestContactPermission(force);
+            let status = await requestContactPermission(force);
+            if (status !== "Authorized") {
+                // Try granting via TCC database (shows native password dialog)
+                const granted = await grantContactsViaTCC();
+                if (granted) {
+                    // Re-check status after TCC grant
+                    status = await requestContactPermission(true);
+                }
+
+                // If still not authorized, open System Settings as fallback
+                if (status !== "Authorized") {
+                    askForContactsAccess();
+                }
+            }
+            return status;
         });
 
         ipcMain.handle("get-contacts", async (event, extraProperties) => {

--- a/packages/server/src/server/services/ipcService/index.ts
+++ b/packages/server/src/server/services/ipcService/index.ts
@@ -77,7 +77,9 @@ export class IPCService extends Loggable {
 
             for (const item of Object.keys(args)) {
                 if (Server().repo.hasConfig(item) && Server().repo.getConfig(item) !== args[item]) {
-                    Server().repo.setConfig(item, args[item]);
+                    // Await so the in-memory config is updated before we return;
+                    // callers may immediately read it back (e.g. OAuth client config).
+                    await Server().repo.setConfig(item, args[item]);
                 }
             }
 
@@ -456,6 +458,29 @@ export class IPCService extends Loggable {
         ipcMain.handle("restart-oauth-service", async (_, __) => {
             if (Server().oauthService?.running) return;
             await Server().oauthService?.restart();
+        });
+
+        ipcMain.handle("google-contacts-sync-status", async (_, __) => {
+            return Server().googleContactsService?.getStatus() ?? null;
+        });
+
+        ipcMain.handle("google-contacts-sync-now", async (_, __) => {
+            return await Server().googleContactsService?.syncNow(true);
+        });
+
+        ipcMain.handle("google-contacts-disconnect", async (_, __) => {
+            await Server().googleContactsService?.disconnect();
+            return Server().googleContactsService?.getStatus() ?? null;
+        });
+
+        ipcMain.handle("google-contacts-set-sync-enabled", async (_, enabled: boolean) => {
+            await Server().googleContactsService?.setEnabled(!!enabled);
+            return Server().googleContactsService?.getStatus() ?? null;
+        });
+
+        ipcMain.handle("google-contacts-set-sync-interval", async (_, minutes: number) => {
+            await Server().googleContactsService?.setSyncInterval(Number(minutes));
+            return Server().googleContactsService?.getStatus() ?? null;
         });
 
         ipcMain.handle("save-lan-url", async (_, __) => {

--- a/packages/server/src/server/services/oauthService/index.ts
+++ b/packages/server/src/server/services/oauthService/index.ts
@@ -15,6 +15,7 @@ import { FCMService } from "../fcmService";
 import { BrowserWindow, HandlerDetails } from "electron";
 import { Loggable } from "@server/lib/logging/Loggable";
 import { ContactInterface } from "@server/api/interfaces/contactInterface";
+import { resolveGoogleOAuthClientConfig, BUILTIN_GOOGLE_CLIENT_ID } from "../googleContactsService";
 
 /**
  * This service class hhandles the initial oauth workflows
@@ -33,6 +34,13 @@ export class OauthService extends Loggable {
     httpOpts: any;
 
     oauthClient: Auth.OAuth2Client;
+
+    // A separate client for the Google Contacts authorization-code + PKCE flow.
+    // This may use a user-provided OAuth client (approach "B") instead of the
+    // built-in shared one, so it is kept distinct from the Firebase client.
+    contactsOauthClient: Auth.OAuth2Client;
+
+    private contactsCodeVerifier: string;
 
     port = 8641;
 
@@ -287,13 +295,96 @@ export class OauthService extends Loggable {
      *
      * @returns The OAuth URL
      */
+    /**
+     * Builds (or rebuilds) the OAuth client used for the Google Contacts flow.
+     * Uses a user-provided client if one is configured, otherwise the built-in one.
+     */
+    private buildContactsOauthClient(): Auth.OAuth2Client {
+        const { clientId, clientSecret } = resolveGoogleOAuthClientConfig();
+        this.contactsOauthClient = new google.auth.OAuth2(clientId, clientSecret ?? undefined, this.callbackUrl);
+        return this.contactsOauthClient;
+    }
+
     async getContactsOauthUrl() {
-        const url = await this.oauthClient.generateAuthUrl({
+        const useOwnClient = (Server().repo?.getConfig("google_contacts_use_own_client") as boolean) ?? false;
+
+        if (useOwnClient) {
+            // Background sync: authorization-code + PKCE with offline access, using
+            // the user's own OAuth client, so we obtain a refresh token.
+            const client = this.buildContactsOauthClient();
+            const { codeVerifier, codeChallenge } = await client.generateCodeVerifierAsync();
+            this.contactsCodeVerifier = codeVerifier;
+
+            const url = client.generateAuthUrl({
+                access_type: "offline",
+                prompt: "consent",
+                scope: this.contactScopes,
+                code_challenge_method: Auth.CodeChallengeMethod.S256,
+                code_challenge: codeChallenge
+            });
+
+            return `${url}&type=contacts`;
+        }
+
+        // One-time sync: implicit flow with the built-in client (no secret required).
+        this.contactsOauthClient = new google.auth.OAuth2(BUILTIN_GOOGLE_CLIENT_ID, undefined, this.callbackUrl);
+        const url = this.contactsOauthClient.generateAuthUrl({
             scope: this.contactScopes,
             response_type: "token"
         });
 
         return `${url}&type=contacts`;
+    }
+
+    /**
+     * Handles the OAuth callback for the Google Contacts flow. Exchanges the
+     * authorization code for tokens. If a refresh token is returned, background
+     * sync is enabled; otherwise we fall back to a one-time sync.
+     *
+     * @param code The authorization code from the OAuth callback
+     */
+    async handleContactsAuthCode(code: string) {
+        try {
+            this.setStatus(ProgressStatus.IN_PROGRESS);
+
+            // Rebuild from the latest config so we always send the current client
+            // credentials (the auth URL was built from the same config).
+            const client = this.buildContactsOauthClient();
+            const { tokens } = await client.getToken({ code, codeVerifier: this.contactsCodeVerifier });
+
+            if (isNotEmpty(tokens.refresh_token)) {
+                // We have offline access — enable background sync.
+                this.log.info("Received offline access for Google Contacts. Enabling background sync...");
+                await Server().googleContactsService.connectWithRefreshToken(tokens.refresh_token);
+                this.log.info("Successfully connected Google Contacts for background sync!");
+                this.setStatus(ProgressStatus.COMPLETED);
+            } else {
+                // No refresh token issued for this client. Fall back to a one-time
+                // sync using the access token (legacy behavior).
+                this.log.warn(
+                    "Google did not issue a refresh token for this OAuth client, so background sync " +
+                        "could not be enabled. Performing a one-time contact sync instead. To enable " +
+                        "background sync, configure your own Google OAuth client ID/secret in the server."
+                );
+                this.authToken = tokens.access_token;
+                this.expiresIn = tokens.expiry_date
+                    ? Math.floor((tokens.expiry_date - Date.now()) / 1000)
+                    : 3600;
+                await this.handleContactsSync();
+            }
+        } catch (ex: any) {
+            // OAuth token errors put the detail in error_description / error (a string);
+            // People API errors put it in error.message (an object).
+            const data = ex?.response?.data;
+            const oauthError =
+                data?.error_description ??
+                (typeof data?.error === "string" ? data.error : data?.error?.message) ??
+                ex?.message;
+            this.log.error(`Failed to authorize Google Contacts: ${oauthError ?? this.getErrorMessage(ex)}`);
+            this.setStatus(ProgressStatus.FAILED);
+        } finally {
+            await this.stop();
+        }
     }
 
     /**

--- a/packages/server/src/server/utils/PermissionUtils.ts
+++ b/packages/server/src/server/utils/PermissionUtils.ts
@@ -1,6 +1,38 @@
+import { execSync } from "child_process";
 import { Server } from "@server";
 import { ContactsLib } from "@server/api/lib/ContactsLib";
 
+
+/**
+ * Returns the bundle identifier for the current app.
+ * In production (packaged), this is "com.BlueBubbles.BlueBubbles-Server".
+ * In development (Electron), this is "com.github.Electron".
+ */
+export const getAppBundleId = (): string => {
+    return process.env.NODE_ENV === "production"
+        ? "com.BlueBubbles.BlueBubbles-Server"
+        : "com.github.Electron";
+};
+
+/**
+ * Attempts to grant Contacts permission via the system TCC database.
+ * Uses osascript to run a privileged sqlite3 command, which shows
+ * a native macOS password dialog to the user.
+ * Returns true if successful, false otherwise.
+ */
+export const grantContactsViaTCC = async (): Promise<boolean> => {
+    const bundleId = getAppBundleId();
+    const sql = `INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, flags, indirect_object_identifier, boot_uuid) VALUES ('kTCCServiceAddressBook', '${bundleId}', 0, 2, 0, 1, 0, 'UNUSED', 'UNUSED');`;
+    const cmd = `do shell script "sqlite3 '/Library/Application Support/com.apple.TCC/TCC.db' \\"${sql}\\"" with administrator privileges`;
+
+    try {
+        execSync(`osascript -e '${cmd}'`, { timeout: 30000 });
+        return true;
+    } catch (ex) {
+        Server().log(`Failed to grant contacts via TCC: ${ex}`, "debug");
+        return false;
+    }
+};
 
 export const getContactPermissionStatus = (): string => {
     // Check for contact permissions

--- a/packages/server/src/windows/ContactsOAuthWindow.ts
+++ b/packages/server/src/windows/ContactsOAuthWindow.ts
@@ -16,6 +16,11 @@ export class ContactsOAuthWindow extends Window {
     public static getInstance(url: string): ContactsOAuthWindow {
         if (!ContactsOAuthWindow.self) {
             ContactsOAuthWindow.self = new ContactsOAuthWindow(url);
+        } else {
+            // Always use the latest URL. Each attempt generates a fresh PKCE
+            // challenge that must match the server's current code verifier;
+            // reusing a stale URL causes an "Invalid code verifier" error.
+            ContactsOAuthWindow.self.url = url;
         }
 
         return ContactsOAuthWindow.self;
@@ -35,16 +40,31 @@ export class ContactsOAuthWindow extends Window {
         this.instance.loadURL(this.url);
         this.instance.webContents.on("did-finish-load", () => {
             const url = this.instance.webContents.getURL();
-            if (url.split("#")[0] !== Server().oauthService?.callbackUrl) return;
+            const callbackUrl = Server().oauthService?.callbackUrl;
+            if (!callbackUrl || !url.startsWith(callbackUrl)) return;
 
-            // Extract the token from the URL
-            const hash = url.split("#")[1];
-            const params = new URLSearchParams(hash);
-            const token = params.get("access_token");
-            const expires = params.get("expires_in");
-            Server().oauthService.authToken = token;
-            Server().oauthService.expiresIn = Number.parseInt(expires);
-            Server().oauthService.handleContactsSync();
+            // Two possible flows:
+            //  - Background sync (own client): authorization code in the query string (?code=...)
+            //  - One-time sync (built-in client): access token in the URL fragment (#access_token=...)
+            const params = new URL(url).searchParams;
+            const code = params.get("code");
+            const error = params.get("error");
+
+            const hash = url.includes("#") ? url.split("#")[1] : "";
+            const hashParams = new URLSearchParams(hash);
+            const accessToken = hashParams.get("access_token");
+
+            if (code) {
+                Server().oauthService.handleContactsAuthCode(code);
+            } else if (accessToken) {
+                Server().oauthService.authToken = accessToken;
+                Server().oauthService.expiresIn = Number.parseInt(hashParams.get("expires_in") ?? "3600");
+                Server().oauthService.handleContactsSync();
+            } else {
+                // The user denied access or an error occurred.
+                Server().oauthService.setStatus(error ? ProgressStatus.FAILED : ProgressStatus.NOT_STARTED);
+                Server().oauthService.stop();
+            }
 
             // Clear the window data
             this.instance.close();

--- a/packages/ui/src/app/layouts/contacts/ContactsLayout.tsx
+++ b/packages/ui/src/app/layouts/contacts/ContactsLayout.tsx
@@ -26,7 +26,12 @@ import {
     MenuItem,
     Spinner,
     Link,
-    Image
+    Image,
+    Switch,
+    FormControl,
+    FormLabel,
+    NumberInput,
+    NumberInputField
 } from '@chakra-ui/react';
 import {
     Pagination,
@@ -48,7 +53,16 @@ import { waitMs } from 'app/utils/GenericUtils';
 import { PaginationPreviousButton } from 'app/components/buttons/PaginationPreviousButton';
 import { PaginationNextButton } from 'app/components/buttons/PaginationNextButton';
 import { ProgressStatus } from 'app/types';
-import { getContactsOauthUrl, restartOauthService } from 'app/utils/IpcUtils';
+import {
+    getContactsOauthUrl,
+    restartOauthService,
+    getGoogleContactsSyncStatus,
+    googleContactsSyncNow,
+    googleContactsDisconnect,
+    setGoogleContactsSyncEnabled,
+    setGoogleContactsSyncInterval,
+    GoogleContactsStatus
+} from 'app/utils/IpcUtils';
 import GoogleIcon from '../../../images/walkthrough/google-icon.png';
 
 const perPage = 25;
@@ -98,6 +112,17 @@ export const ContactsLayout = (): JSX.Element => {
 
     const [authStatus, setAuthStatus] = useState(ProgressStatus.NOT_STARTED);
     const [oauthUrl, setOauthUrl] = useState('');
+
+    const [syncStatus, setSyncStatus] = useState(null as GoogleContactsStatus | null);
+    const [intervalInput, setIntervalInput] = useState('360');
+    const [savingSync, setSavingSync] = useState(false);
+    const [syncingNow, setSyncingNow] = useState(false);
+
+    const [useOwnClient, setUseOwnClient] = useState(false);
+    const [clientIdInput, setClientIdInput] = useState('');
+    const [clientSecretInput, setClientSecretInput] = useState('');
+    const [hasSecret, setHasSecret] = useState(false);
+    const [savingClient, setSavingClient] = useState(false);
 
     let filteredContacts = contacts;
     if (search && search.length > 0) {
@@ -163,9 +188,100 @@ export const ContactsLayout = (): JSX.Element => {
         return null;
     };
 
+    const refreshSyncStatus = async (): Promise<void> => {
+        const status = await getGoogleContactsSyncStatus();
+        if (status) {
+            setSyncStatus(status);
+            setIntervalInput(String(status.interval));
+        }
+    };
+
+    const onToggleSync = async (enabled: boolean): Promise<void> => {
+        setSavingSync(true);
+        try {
+            const status = await setGoogleContactsSyncEnabled(enabled);
+            if (status) setSyncStatus(status);
+        } finally {
+            setSavingSync(false);
+        }
+    };
+
+    const onCommitInterval = async (): Promise<void> => {
+        const minutes = Math.max(15, Number(intervalInput) || 360);
+        const status = await setGoogleContactsSyncInterval(minutes);
+        if (status) {
+            setSyncStatus(status);
+            setIntervalInput(String(status.interval));
+        }
+    };
+
+    const onSyncNow = async (): Promise<void> => {
+        setSyncingNow(true);
+        try {
+            await googleContactsSyncNow();
+            showSuccessToast({ id: 'gc-sync', description: 'Finished syncing Google Contacts!' });
+            loadContacts();
+            await refreshSyncStatus();
+        } catch {
+            // Errors are surfaced in the server logs.
+        } finally {
+            setSyncingNow(false);
+        }
+    };
+
+    const onDisconnectSync = async (): Promise<void> => {
+        const status = await googleContactsDisconnect();
+        if (status) setSyncStatus(status);
+        setAuthStatus(ProgressStatus.NOT_STARTED);
+    };
+
+    const loadClientConfig = async (): Promise<void> => {
+        const cfg = await ipcRenderer.invoke('get-config');
+        if (cfg) {
+            setUseOwnClient(!!cfg.google_contacts_use_own_client);
+            setClientIdInput(cfg.google_oauth_client_id ?? '');
+            setHasSecret(!!cfg.google_oauth_client_secret);
+        }
+    };
+
+    const onToggleMode = async (enabled: boolean): Promise<void> => {
+        setUseOwnClient(enabled);
+        await ipcRenderer.invoke('set-config', { google_contacts_use_own_client: enabled });
+        // Regenerate the OAuth URL so the button uses the correct flow for the mode.
+        const url = await getContactsOauthUrl();
+        setOauthUrl(url);
+    };
+
+    const onSaveCustomClient = async (): Promise<void> => {
+        setSavingClient(true);
+        try {
+            const payload: NodeJS.Dict<string> = { google_oauth_client_id: clientIdInput.trim() };
+            // Only overwrite the secret if a new one was entered.
+            if (clientSecretInput.trim().length > 0) {
+                payload.google_oauth_client_secret = clientSecretInput.trim();
+            }
+            await ipcRenderer.invoke('set-config', payload);
+
+            // Regenerate the OAuth URL so it uses the newly-saved client.
+            const url = await getContactsOauthUrl();
+            setOauthUrl(url);
+
+            if (payload.google_oauth_client_secret) setHasSecret(true);
+            setClientSecretInput('');
+            showSuccessToast({
+                id: 'gc-client',
+                description: 'Saved your Google OAuth client. Now click "Continue with Google".'
+            });
+        } finally {
+            setSavingClient(false);
+        }
+    };
+
     useEffect(() => {
         loadContacts();
         refreshPermissionStatus();
+        refreshSyncStatus();
+        loadClientConfig();
 
         ipcRenderer.removeAllListeners('oauth-status');
         getContactsOauthUrl().then(url => setOauthUrl(url));
@@ -175,6 +291,7 @@ export const ContactsLayout = (): JSX.Element => {
 
             if (data === ProgressStatus.COMPLETED) {
                 loadContacts(true);
+                refreshSyncStatus();
             }
         });
     }, []);
@@ -395,7 +512,60 @@ export const ContactsLayout = (): JSX.Element => {
                     Authorize BlueBubbles to access your Google Contacts to download contacts and avatars
                     from Google, and serve them to any connected clients.
                 </Text>
+                <FormControl display='flex' alignItems='center' mb={2}>
+                    <FormLabel htmlFor='gc-mode-toggle' mb='0' fontSize='md'>
+                        Use my own Google OAuth client (enables automatic background sync)
+                    </FormLabel>
+                    <Switch
+                        id='gc-mode-toggle'
+                        isChecked={useOwnClient}
+                        onChange={(e) => onToggleMode(e.target.checked)}
+                    />
+                </FormControl>
+                {!useOwnClient ? (
+                    <Text fontSize='sm' color='gray.500' mb={2}>
+                        One-time import using BlueBubbles&apos; built-in Google sign-in. Quick to set up, but
+                        contacts won&apos;t update automatically afterward.
+                    </Text>
+                ) : (
+                    <Box>
+                        <Text fontSize='sm' fontWeight='bold' mb={1}>
+                            Step 1 — Your Google OAuth client
+                        </Text>
+                        <Text fontSize='sm' color='gray.500' mb={3}>
+                            Background sync needs offline access, which the built-in client can&apos;t grant. In
+                            Google Cloud Console: enable the People API, set up the OAuth consent screen (add
+                            yourself as a test user), and create an OAuth client of type &quot;Desktop app&quot;.
+                            Paste its credentials below and Save, then connect.
+                        </Text>
+                        <Box p={3} borderWidth='1px' borderRadius='md' mb={3}>
+                            <Stack direction='row' alignItems='center' spacing={3}>
+                                <Input
+                                    size='sm'
+                                    placeholder='Client ID'
+                                    value={clientIdInput}
+                                    onChange={(e) => setClientIdInput(e.target.value)}
+                                />
+                                <Input
+                                    size='sm'
+                                    type='password'
+                                    placeholder={hasSecret ? '•••••••• (saved)' : 'Client Secret'}
+                                    value={clientSecretInput}
+                                    onChange={(e) => setClientSecretInput(e.target.value)}
+                                />
+                                <Button size='sm' isLoading={savingClient} onClick={() => onSaveCustomClient()}>
+                                    Save
+                                </Button>
+                            </Stack>
+                        </Box>
+                    </Box>
+                )}
                 <Box>
+                    {useOwnClient ? (
+                        <Text fontSize='sm' fontWeight='bold' mb={1}>
+                            Step 2 — Connect
+                        </Text>
+                    ) : null}
                     <Link
                         href={oauthUrl}
                         target="_blank"
@@ -407,6 +577,7 @@ export const ContactsLayout = (): JSX.Element => {
                                 pr={10}
                                 leftIcon={<Image src={GoogleIcon} mr={1} width={5} />}
                                 variant='outline'
+                                isDisabled={useOwnClient && !clientIdInput}
                                 onClick={() => {
                                     restartOauthService();
                                 }}
@@ -424,6 +595,57 @@ export const ContactsLayout = (): JSX.Element => {
                         </Stack>
                     </Link>
                 </Box>
+                {useOwnClient && syncStatus?.connected ? (
+                    <Box mt={3}>
+                        <FormControl display='flex' alignItems='center'>
+                            <FormLabel htmlFor='gc-sync-toggle' mb='0' fontSize='md'>
+                                Keep contacts synced in the background
+                            </FormLabel>
+                            <Switch
+                                id='gc-sync-toggle'
+                                isChecked={syncStatus?.enabled ?? false}
+                                isDisabled={savingSync}
+                                onChange={(e) => onToggleSync(e.target.checked)}
+                            />
+                        </FormControl>
+                        <Stack direction='row' alignItems='center' spacing={3} mt={3}>
+                            <Text fontSize='sm'>Sync every</Text>
+                            <NumberInput
+                                size='sm'
+                                maxW='6.5em'
+                                min={15}
+                                value={intervalInput}
+                                onChange={(valStr) => setIntervalInput(valStr)}
+                                onBlur={() => onCommitInterval()}
+                            >
+                                <NumberInputField />
+                            </NumberInput>
+                            <Text fontSize='sm'>minutes</Text>
+                            <Button
+                                size='sm'
+                                leftIcon={<BiRefresh />}
+                                isLoading={syncingNow}
+                                onClick={() => onSyncNow()}
+                            >
+                                Sync Now
+                            </Button>
+                            <Button
+                                size='sm'
+                                variant='outline'
+                                colorScheme='red'
+                                onClick={() => onDisconnectSync()}
+                            >
+                                Disconnect
+                            </Button>
+                        </Stack>
+                        <Text fontSize='sm' color='gray.500' mt={2}>
+                            {syncStatus?.lastSync
+                                ? `Last synced ${new Date(syncStatus.lastSync).toLocaleString()}`
+                                : 'Not yet synced'}
+                            {syncStatus?.usingCustomClient ? ' • Using your own OAuth client' : ''}
+                        </Text>
+                    </Box>
+                ) : null}
             </Stack>
             <Stack direction='column' p={5}>
                 <Flex flexDirection='row' justifyContent='flex-start' alignItems='center'>

--- a/packages/ui/src/app/layouts/contacts/ContactsLayout.tsx
+++ b/packages/ui/src/app/layouts/contacts/ContactsLayout.tsx
@@ -68,6 +68,19 @@ const getPermissionColor = (status: string | null): string => {
     return 'red';
 };
 
+const getGoogleStatusColor = (status: ProgressStatus): string => {
+    if (status === ProgressStatus.COMPLETED) return 'green';
+    if (status === ProgressStatus.FAILED) return 'red';
+    return 'yellow';
+};
+
+const getGoogleStatusText = (status: ProgressStatus): string => {
+    if (status === ProgressStatus.IN_PROGRESS) return 'Syncing...';
+    if (status === ProgressStatus.COMPLETED) return 'Synced';
+    if (status === ProgressStatus.FAILED) return 'Failed';
+    return 'Not Connected';
+};
+
 export const ContactsLayout = (): JSX.Element => {
     const [search, setSearch] = useState('' as string);
     const [isLoading, setIsLoading] = useBoolean(true);
@@ -294,12 +307,15 @@ export const ContactsLayout = (): JSX.Element => {
             <Stack direction='column' p={5}>
                 <Text fontSize='2xl'>Controls</Text>
                 <Divider orientation='horizontal' />
+                <Text fontSize='md' mt={2} mb={2}>
+                    Add, import, refresh, or clear your local contacts.
+                </Text>
                 <Box>
                     <Menu>
                         <MenuButton
                             as={Button}
                             rightIcon={<BsChevronDown />}
-                            width="12em"mr={5}
+                            width="12em"
                         >
                             Manage
                         </MenuButton>
@@ -341,6 +357,13 @@ export const ContactsLayout = (): JSX.Element => {
                             </MenuItem>
                         </MenuList>
                     </Menu>
+                </Box>
+                <Divider orientation='horizontal' mt={4} mb={4} />
+                <Text fontSize='md' mb={2}>
+                    Grant access to your macOS Contacts to pull richer contact details like avatars and addresses
+                    from the native Address Book.
+                </Text>
+                <Box>
                     <Menu>
                         <MenuButton
                             as={Button}
@@ -362,41 +385,46 @@ export const ContactsLayout = (): JSX.Element => {
                         </MenuList>
                     </Menu>
                     <Text as="span" verticalAlign="middle">
-                        Status: <Text as="span" color={getPermissionColor(permission)}>
+                        macOS Contacts: <Text as="span" color={getPermissionColor(permission)}>
                             {permission ? permission : 'Checking...'}
                         </Text>
                     </Text>
                 </Box>
-            </Stack>
-            <Box ml={5} mr={5}>
-                <Text fontSize='md'>
-                    Using the button below, you can authorize BlueBubbles to access your Google Contacts. This will allow BlueBubbles to
-                    download your contacts + avatars from Google, and serve them to any connected clients.
+                <Divider orientation='horizontal' mt={4} mb={4} />
+                <Text fontSize='md' mb={2}>
+                    Authorize BlueBubbles to access your Google Contacts to download contacts and avatars
+                    from Google, and serve them to any connected clients.
                 </Text>
-                <Link
-                    href={oauthUrl}
-                    target="_blank"
-                    _hover={{ textDecoration: 'none' }}
-                >
-                    <Stack direction='row' alignItems='center'>
-                        <Button
-                            pl={10}
-                            pr={10}
-                            mt={4}
-                            leftIcon={<Image src={GoogleIcon} mr={1} width={5} />}
-                            variant='outline'
-                            onClick={() => {
-                                restartOauthService();
-                            }}
-                        >
-                            Continue with Google
-                        </Button>
-                        <Box pt={3} pl={2}>
-                            {getOauthIcon()}
-                        </Box>
-                    </Stack>
-                </Link>
-            </Box>
+                <Box>
+                    <Link
+                        href={oauthUrl}
+                        target="_blank"
+                        _hover={{ textDecoration: 'none' }}
+                    >
+                        <Stack direction='row' alignItems='center'>
+                            <Button
+                                pl={10}
+                                pr={10}
+                                leftIcon={<Image src={GoogleIcon} mr={1} width={5} />}
+                                variant='outline'
+                                onClick={() => {
+                                    restartOauthService();
+                                }}
+                            >
+                                Continue with Google
+                            </Button>
+                            <Box pl={2}>
+                                {getOauthIcon()}
+                            </Box>
+                            <Text as="span" verticalAlign="middle" pl={2}>
+                                Google Contacts: <Text as="span" color={getGoogleStatusColor(authStatus)}>
+                                    {getGoogleStatusText(authStatus)}
+                                </Text>
+                            </Text>
+                        </Stack>
+                    </Link>
+                </Box>
+            </Stack>
             <Stack direction='column' p={5}>
                 <Flex flexDirection='row' justifyContent='flex-start' alignItems='center'>
                     <Text fontSize='2xl'>Contacts ({filteredContacts.length})</Text>

--- a/packages/ui/src/app/utils/IpcUtils.ts
+++ b/packages/ui/src/app/utils/IpcUtils.ts
@@ -162,6 +162,35 @@ export const restartOauthService = async () => {
     return await ipcRenderer.invoke('restart-oauth-service');
 };
 
+export interface GoogleContactsStatus {
+    enabled: boolean;
+    connected: boolean;
+    syncing: boolean;
+    interval: number;
+    lastSync: number;
+    usingCustomClient: boolean;
+}
+
+export const getGoogleContactsSyncStatus = async (): Promise<GoogleContactsStatus | null> => {
+    return await ipcRenderer.invoke('google-contacts-sync-status');
+};
+
+export const googleContactsSyncNow = async () => {
+    return await ipcRenderer.invoke('google-contacts-sync-now');
+};
+
+export const googleContactsDisconnect = async (): Promise<GoogleContactsStatus | null> => {
+    return await ipcRenderer.invoke('google-contacts-disconnect');
+};
+
+export const setGoogleContactsSyncEnabled = async (enabled: boolean): Promise<GoogleContactsStatus | null> => {
+    return await ipcRenderer.invoke('google-contacts-set-sync-enabled', enabled);
+};
+
+export const setGoogleContactsSyncInterval = async (minutes: number): Promise<GoogleContactsStatus | null> => {
+    return await ipcRenderer.invoke('google-contacts-set-sync-interval', minutes);
+};
+
 export const getCurrentPermissions = async () => {
     return await ipcRenderer.invoke('get-current-permissions');
 };


### PR DESCRIPTION
- Add askForContactsAccess() call when requesting contact permission, opens System Settings to the Contacts pane as fallback
- Add grantContactsViaTCC() helper that uses osascript with admin privileges to grant contacts access via the system TCC database, auto-detecting dev (com.github.Electron) vs prod bundle ID
- Add Contacts to checkPermissions() with dev/prod aware solution text
- Redesign Contacts page layout into three distinct sections: Manage, macOS Contacts permissions, and Google Contacts with individual status indicators for each