### PR TITLE
fix: encode voice memo attachments as Opus instead of LEI16 PCM

### DIFF
--- a/packages/server/src/server/fileSystem/index.ts
+++ b/packages/server/src/server/fileSystem/index.ts
@@ -541,7 +541,7 @@ export class FileSystem {
     static async convertMp3ToCaf(originalPath: string, outputPath: string): Promise<void> {
         const oldPath = FileSystem.getRealPath(originalPath);
         const output = await FileSystem.execShellCommand(
-            `/usr/bin/afconvert -f caff -d LEI16@44100 -c 1 "${oldPath}" "${outputPath}"`
+            `/usr/bin/afconvert -f caff -d opus@24000 -c 1 "${oldPath}" "${outputPath}"`
         );
         if (isNotEmpty(output) && output.includes("Error:")) {
             throw Error(`Failed to convert audio to CAF: ${output}`);


### PR DESCRIPTION
## The problem

When a client sends an attachment with \`isAudioMessage=true\`, the
server calls \`FileSystem.convertMp3ToCaf\` to transcode the input
into a CAF file before handing it off. The CAF arrives at iMessage
and is displayed as a regular file attachment with an \`.mp3.mp3\` or
\`.caf\` filename, rather than an iMessage voice bubble with a waveform
and a play button.

## Root cause

\`FileSystem.convertMp3ToCaf\` currently runs:

\`\`\`sh
/usr/bin/afconvert -f caff -d LEI16@44100 -c 1 input output
\`\`\`

\`LEI16@44100\` is 16-bit little-endian PCM at 44.1 kHz. The resulting
CAF is valid and playable as audio, but iMessage's voice-memo
renderer specifically requires the CAF to contain **Opus**. When it
sees PCM inside CAF, it falls back to rendering the attachment as a
generic file, which is what users see.

This matches the reproducer and analysis in
[openclaw/openclaw#1526](https://github.com/openclaw/openclaw/issues/1526), which identified the same failure on
macOS 15 -> iOS 26.

## The fix

Change the afconvert codec flag from \`LEI16@44100\` to \`opus@24000\`.

\`\`\`diff
-            \`/usr/bin/afconvert -f caff -d LEI16@44100 -c 1 \"\${oldPath}\" \"\${outputPath}\"\`
+            \`/usr/bin/afconvert -f caff -d opus@24000 -c 1 \"\${oldPath}\" \"\${outputPath}\"\`
\`\`\`

Opus at 24 kHz mono is the format iMessage uses natively for voice
memos. \`afconvert\` ships with every macOS version this project
supports, so there is no new dependency.

Both send paths that call this helper benefit from the fix:

- \`packages/server/src/server/api/apple/actions.ts\` (AppleScript)
- \`packages/server/src/server/api/interfaces/messageInterface.ts\`
  (Private API)

## Verification

Tested on macOS 26.3, Apple Silicon:

\`\`\`
$ afconvert -f caff -d opus@24000 -c 1 test.mp3 test.caf
$ afinfo test.caf
File:           test.caf
File type ID:   caff
Data format:     1 ch,  24000 Hz, opus (0x00000000) 0 bits/channel
Channel layout: Mono
\`\`\`

The resulting CAF is rendered as an iMessage voice bubble (waveform
+ play button) on receiving devices when delivered via an
\`isAudioMessage=true\` send that reaches the voice-memo code path in
iMessage (which on BlueBubbles requires the Private API send path).

Note: this fix is necessary but not by itself sufficient to get
voice bubbles on a BlueBubbles install. The Private API send path
is also required, since the AppleScript path has no way to mark an
attachment as a voice memo. This PR only addresses the codec bug
that silently breaks the Private API path's voice-memo output.