### PR TITLE
fix(webhookService): redact password/guid from logged webhook URL

### DIFF
--- a/packages/server/src/server/services/webhookService/index.ts
+++ b/packages/server/src/server/services/webhookService/index.ts
@@ -8,6 +8,25 @@ export type WebhookEvent = {
 };
 
 /**
+ * Redact credential-bearing query parameters (password, guid) from a webhook
+ * URL before writing it to a log. Clients commonly register webhook URLs that
+ * embed the server password or a shared guid as a query string, so logging the
+ * raw URL writes that secret to disk on every dispatch. Falls back to the
+ * input unchanged if parsing fails.
+ */
+const redactWebhookUrl = (url: string): string => {
+    try {
+        const parsed = new URL(url);
+        for (const key of ["password", "guid"]) {
+            if (parsed.searchParams.has(key)) parsed.searchParams.set(key, "***");
+        }
+        return parsed.toString();
+    } catch {
+        return url;
+    }
+};
+
+/**
  * Handles dispatching webhooks
  */
 export class WebhookService extends Loggable {
@@ -18,11 +37,12 @@ export class WebhookService extends Loggable {
         for (const i of webhooks) {
             const eventTypes = JSON.parse(i.events) as Array<string>;
             if (!eventTypes.includes("*") && !eventTypes.includes(event.type)) continue;
-            this.log.debug(`Dispatching event to webhook: ${i.url}`);
+            const safeUrl = redactWebhookUrl(i.url);
+            this.log.debug(`Dispatching event to webhook: ${safeUrl}`);
 
             // We don't need to await this
             this.sendPost(i.url, event).catch(ex => {
-                this.log.debug(`Failed to dispatch "${event.type}" event to webhook: ${i.url}`);
+                this.log.debug(`Failed to dispatch "${event.type}" event to webhook: ${safeUrl}`);
                 this.log.debug(`  -> Error: ${ex?.message ?? String(ex)}`);
                 this.log.debug(`  -> Status Text: ${ex?.response?.statusText}`);
             });


### PR DESCRIPTION
## The problem

On every webhook dispatch, \`WebhookService.dispatch\` logs the raw registered URL at debug level:

\`\`\`ts
this.log.debug(\`Dispatching event to webhook: \${i.url}\`);
\`\`\`

Clients commonly register webhook URLs that embed the server password as a query parameter (this is what BlueBubbles itself generates for integrations like Hermes — the \`/api/v1/webhook\` REST API accepts \`?password=...\` URLs and the Hermes adapter registers them that way). The result is that the server password is written in cleartext to \`bluebubbles-server.log\` on every single inbound iMessage event.

That log is readable via \`/api/v1/server/logs\`. Gated by the same password, so the severity is limited — but surprising, avoidable, and also leaks into any copy/paste of the log (bug reports, Discord troubleshooting). The same URL is echoed on dispatch failures a few lines down.

## The fix

Add a tiny \`redactWebhookUrl\` helper that parses the URL and replaces \`password\` and \`guid\` query-parameter values with \`***\` before logging. The outgoing HTTP request still uses the original URL unchanged, so there's no functional change.

Before:

\`\`\`
[WebhookService] Dispatching event to webhook: http://localhost:8645/bluebubbles-webhook?password=SuperSecret123
\`\`\`

After:

\`\`\`
[WebhookService] Dispatching event to webhook: http://localhost:8645/bluebubbles-webhook?password=***
\`\`\`

## Related

\`packages/server/src/server/api/http/api/v1/middleware/logMiddleware.ts\` already redacts \`password\` from **inbound** request query params (line 11: \`if (Object.keys(params).includes(\"password\")) delete params.password;\`). This PR closes the matching gap on **outbound** webhook dispatch logs.

Happy to factor the helper into a shared util if maintainers prefer — kept it inline to keep the diff minimal.