### PR TITLE
fix(setDockIcon): use setActivationPolicy('accessory') for reliable Dock-hiding on Tahoe + previous macOS

### DIFF
--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -962,11 +962,20 @@ class BlueBubblesServer extends EventEmitter {
         if (!this.repo || !this.repo.db) return;
 
         const hideDockIcon = this.repo.getConfig("hide_dock_icon") as boolean;
+        // Use app.setActivationPolicy() instead of app.dock.hide()/show().
+        // setActivationPolicy is the runtime equivalent of LSUIElement in
+        // Info.plist and reliably hides the app from the Dock + app
+        // switcher across window-creation cycles. app.dock.hide() alone is
+        // brittle: creating a BrowserWindow after the call re-promotes the
+        // app to the Dock, and on macOS 26 (Tahoe) app.dock.hide() does not
+        // take effect at all — neither from startup config-load nor from
+        // the in-app UI toggle. The previous `app.show()` after dock.hide()
+        // was also counterproductive: app.show() focuses the app, which
+        // re-activates the Dock icon as a side effect.
         if (hideDockIcon) {
-            app.dock.hide();
-            app.show();
+            app.setActivationPolicy("accessory");
         } else {
-            app.dock.show();
+            app.setActivationPolicy("regular");
         }
     }
 


### PR DESCRIPTION
## Summary

The current `setDockIcon()` implementation calls `app.dock.hide()` followed by `app.show()` when `hide_dock_icon=true`. This is unreliable in several ways, and on macOS 26 (Tahoe) it does not work at all.

This PR replaces both calls with `app.setActivationPolicy('accessory'|'regular')` — the proper Electron API for "background-only app, no Dock presence, no app-switcher presence." It is the runtime equivalent of `LSUIElement=true` in Info.plist.

## Why the current implementation breaks

1. **`app.show()` re-promotes to Dock.** `app.show()` focuses the application, which on macOS has the side effect of re-activating the Dock icon. The very next line after `app.dock.hide()` undoes the hide.

2. **`app.dock.hide()` doesn't survive `BrowserWindow` creation.** Even when called before any window exists, subsequent window-creation calls re-promote the app to the Dock. The secondary `setDockIcon()` call in `initServerComponents()` doesn't reliably catch this.

3. **On macOS 26 (Tahoe), `app.dock.hide()` is a no-op.** Verified 2026-05-22 on Tahoe 26.4.1 build 25E253 with BB v1.9.9 + Electron's bundled version. The Dock icon stays visible:
   - From startup with `hide_dock_icon=1` in config — Dock icon stays
   - From in-app UI toggle of "Hide Dock Icon" while BB is running — Dock icon stays

## Fix

```typescript
if (hideDockIcon) {
    app.setActivationPolicy("accessory");
} else {
    app.setActivationPolicy("regular");
}
```

`setActivationPolicy('accessory')` tells macOS at the AppKit layer that this is an accessory app — no Dock, no app-switcher entry, no menu bar. It survives window creation cycles and works on every macOS version that supports the API (10.6+).

`setActivationPolicy('regular')` restores the default — the equivalent of the previous `app.dock.show()` path.

## Compatibility

- **No behavior change for users with `hide_dock_icon=false`** (the default).
- Users who had `hide_dock_icon=true` were silently getting no effect on Tahoe; this fixes that.
- Works on macOS 10.6+ (the API is older than the minimum supported macOS). No new dependencies.

## Test plan

- [x] macOS 26.4.1 (Tahoe), Apple Silicon (M2 Mac mini), BB v1.9.9 — verified app.dock.hide() doesn't work
- [ ] macOS 14 (Sonoma) — would appreciate maintainer verification
- [ ] macOS 13 (Ventura) — would appreciate maintainer verification

Happy to iterate or split into smaller commits if preferred.