### PR TITLE
feat: cross-device clipboard sync service

### DIFF
--- a/packages/server/src/server/api/http/api/v1/socketRoutes.ts
+++ b/packages/server/src/server/api/http/api/v1/socketRoutes.ts
@@ -1079,6 +1079,20 @@ export class SocketRoutes {
             return response(cb, "save-vcf", createSuccessResponse(await GeneralInterface.checkForUpdate()));
         });
 
+        /**
+         * Receives clipboard content from a client and writes it to the Mac clipboard.
+         * The ClipboardService will broadcast it to all other connected clients.
+         */
+        socket.on("clipboard-sync", async (params, cb): Promise<void> => {
+            if (!params?.content) return response(cb, "error", createBadRequestResponse("No content provided!"));
+            try {
+                Server().clipboardService.writeFromClient(params.content);
+                return response(cb, "clipboard-sync-success", createSuccessResponse(null));
+            } catch {
+                return response(cb, "clipboard-sync-error", createServerErrorResponse("Failed to sync clipboard!"));
+            }
+        });
+
         socket.on("disconnect", reason => {
             log.info(`Client ${socket.id} disconnected! Reason: ${reason}`);
         });

--- a/packages/server/src/server/events.ts
+++ b/packages/server/src/server/events.ts
@@ -29,3 +29,4 @@ export const THEME_BACKUP_UPDATED = "theme-backup-updated";
 export const IMESSAGE_ALIASES_REMOVED = "imessage-aliases-removed";
 export const FT_CALL_STATUS_CHANGED = "ft-call-status-changed";
 export const NEW_FINDMY_LOCATION = "new-findmy-location";
+export const CLIPBOARD_SYNC = "clipboard-sync";

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -31,7 +31,8 @@ import {
     WebhookService,
     ScheduledMessagesService,
     OauthService,
-    ZrokService
+    ZrokService,
+    ClipboardService
 } from "@server/services";
 import { EventCache } from "@server/eventCache";
 import { runTerminalScript, openSystemPreferences, startMessages } from "@server/api/apple/scripts";
@@ -146,6 +147,8 @@ class BlueBubblesServer extends EventEmitter {
     webhookService: WebhookService;
 
     oauthService: OauthService;
+
+    clipboardService: ClipboardService;
 
     actionHandler: ActionHandler;
 
@@ -497,6 +500,13 @@ class BlueBubblesServer extends EventEmitter {
         } catch (ex: any) {
             this.logger.error(`Failed to start Scheduled Message service! ${ex?.message ?? String(ex)}}`);
         }
+
+        try {
+            this.logger.info("Initializing Clipboard Sync Service...");
+            this.clipboardService = new ClipboardService();
+        } catch (ex: any) {
+            this.logger.error(`Failed to initialize Clipboard Sync service! ${ex?.message ?? String(ex)}}`);
+        }
     }
 
     /**
@@ -537,6 +547,13 @@ class BlueBubblesServer extends EventEmitter {
             await this.scheduledMessages.start();
         } catch (ex: any) {
             this.logger.error(`Failed to start Scheduled Messages service! ${ex?.message ?? String(ex)}}`);
+        }
+
+        try {
+            this.logger.info("Starting Clipboard Sync service...");
+            this.clipboardService.start();
+        } catch (ex: any) {
+            this.logger.error(`Failed to start Clipboard Sync service! ${ex?.message ?? String(ex)}}`);
         }
 
         const privateApiEnabled = this.repo.getConfig("enable_private_api") as boolean;
@@ -604,6 +621,12 @@ class BlueBubblesServer extends EventEmitter {
             this.scheduledMessages?.stop();
         } catch (ex: any) {
             this.logger.error(`Failed to stop Scheduled Messages service! ${ex?.message ?? ex}`);
+        }
+
+        try {
+            this.clipboardService?.stop();
+        } catch (ex: any) {
+            this.logger.error(`Failed to stop Clipboard Sync service! ${ex?.message ?? ex}`);
         }
 
         this.logger.info("Finished stopping services...");

--- a/packages/server/src/server/services/clipboardService/index.ts
+++ b/packages/server/src/server/services/clipboardService/index.ts
@@ -1,0 +1,44 @@
+import { clipboard } from "electron";
+import { Loggable } from "@server/lib/logging/Loggable";
+import { Server } from "@server";
+import { CLIPBOARD_SYNC } from "@server/events";
+
+export class ClipboardService extends Loggable {
+    tag = "ClipboardService";
+
+    private pollInterval: NodeJS.Timeout | null = null;
+    private lastKnown = "";
+    private lastWritten = "";
+    private readonly POLL_MS = 500;
+
+    start() {
+        if (this.pollInterval) return;
+        this.lastKnown = clipboard.readText();
+        this.pollInterval = setInterval(() => this.poll(), this.POLL_MS);
+        this.log.info("Clipboard sync service started");
+    }
+
+    stop() {
+        if (!this.pollInterval) return;
+        clearInterval(this.pollInterval);
+        this.pollInterval = null;
+        this.log.info("Clipboard sync service stopped");
+    }
+
+    // Called by socket handler when a client sends clipboard content.
+    // Updates lastWritten so the next poll doesn't echo it back.
+    writeFromClient(text: string) {
+        this.lastWritten = text;
+        this.lastKnown = text;
+        clipboard.writeText(text);
+    }
+
+    private poll() {
+        const current = clipboard.readText();
+        if (!current || current === this.lastKnown) return;
+        this.lastKnown = current;
+        // Suppress echo of content we just wrote from a client
+        if (current === this.lastWritten) return;
+        Server().emitMessage(CLIPBOARD_SYNC, { content: current }, "normal", false);
+    }
+}

--- a/packages/server/src/server/services/clipboardService/index.ts
+++ b/packages/server/src/server/services/clipboardService/index.ts
@@ -3,6 +3,11 @@ import { Loggable } from "@server/lib/logging/Loggable";
 import { Server } from "@server";
 import { CLIPBOARD_SYNC } from "@server/events";
 
+interface ClipboardItem {
+    text: string;
+    timestamp: number;
+}
+
 export class ClipboardService extends Loggable {
     tag = "ClipboardService";
 
@@ -10,6 +15,8 @@ export class ClipboardService extends Loggable {
     private lastKnown = "";
     private lastWritten = "";
     private readonly POLL_MS = 500;
+    private history: ClipboardItem[] = [];
+    private readonly MAX_HISTORY = 20;
 
     start() {
         if (this.pollInterval) return;
@@ -25,12 +32,17 @@ export class ClipboardService extends Loggable {
         this.log.info("Clipboard sync service stopped");
     }
 
+    getHistory(): ClipboardItem[] {
+        return this.history;
+    }
+
     // Called by socket handler when a client sends clipboard content.
     // Updates lastWritten so the next poll doesn't echo it back.
     writeFromClient(text: string) {
         this.lastWritten = text;
         this.lastKnown = text;
         clipboard.writeText(text);
+        this.addToHistory(text);
     }
 
     private poll() {
@@ -39,6 +51,15 @@ export class ClipboardService extends Loggable {
         this.lastKnown = current;
         // Suppress echo of content we just wrote from a client
         if (current === this.lastWritten) return;
+        this.addToHistory(current);
         Server().emitMessage(CLIPBOARD_SYNC, { content: current }, "normal", false);
+    }
+
+    private addToHistory(text: string) {
+        if (this.history.length > 0 && this.history[0].text === text) return;
+        this.history.unshift({ text, timestamp: Date.now() });
+        if (this.history.length > this.MAX_HISTORY) {
+            this.history.pop();
+        }
     }
 }

--- a/packages/server/src/server/services/index.ts
+++ b/packages/server/src/server/services/index.ts
@@ -11,6 +11,7 @@ import { CertificateService } from "./certificateService";
 import { WebhookService } from "./webhookService";
 import { ScheduledMessagesService } from "./scheduledMessagesService";
 import { OauthService } from "./oauthService";
+import { ClipboardService } from "./clipboardService";
 
 export {
     FCMService,
@@ -25,5 +26,6 @@ export {
     CloudflareService,
     WebhookService,
     ScheduledMessagesService,
-    OauthService
+    OauthService,
+    ClipboardService
 };

--- a/packages/server/src/trays/AppTray.ts
+++ b/packages/server/src/trays/AppTray.ts
@@ -160,7 +160,10 @@ export class AppTray extends Tray {
                     }
                     return history.map(item => ({
                         label: `${item.text.substring(0, 45)}${item.text.length > 45 ? "…" : ""}`,
-                        click: () => Server().emitMessage(CLIPBOARD_SYNC, { content: item.text }, "normal", false)
+                        click: () => {
+                            Server().clipboardService?.writeFromClient(item.text);
+                            Server().emitMessage(CLIPBOARD_SYNC, { content: item.text }, "normal", false);
+                        }
                     }));
                 })()
             },

--- a/packages/server/src/trays/AppTray.ts
+++ b/packages/server/src/trays/AppTray.ts
@@ -2,7 +2,7 @@ import { autoUpdater } from "electron-updater";
 import { Server } from "@server";
 import { FileSystem } from "@server/fileSystem";
 import { Tray } from ".";
-import { SERVER_UPDATE_DOWNLOADING } from "@server/events";
+import { SERVER_UPDATE_DOWNLOADING, CLIPBOARD_SYNC } from "@server/events";
 import { Menu, nativeTheme, Tray as ElectronTray, app } from "electron";
 import { AppWindow } from "@windows/AppWindow";
 import path from "path";
@@ -147,6 +147,22 @@ export class AppTray extends Tray {
             {
                 label: `Caffeinated: ${Server().caffeinate?.isCaffeinated}`,
                 enabled: false
+            },
+            {
+                type: "separator"
+            },
+            {
+                label: "Clipboard History",
+                submenu: (() => {
+                    const history = Server().clipboardService?.getHistory() ?? [];
+                    if (history.length === 0) {
+                        return [{ label: "No items yet", enabled: false }];
+                    }
+                    return history.map(item => ({
+                        label: `${item.text.substring(0, 45)}${item.text.length > 45 ? "…" : ""}`,
+                        click: () => Server().emitMessage(CLIPBOARD_SYNC, { content: item.text }, "normal", false)
+                    }));
+                })()
             },
             {
                 type: "separator"


### PR DESCRIPTION
## Summary

- Adds `ClipboardService` that polls the Mac clipboard every 500 ms and broadcasts `clipboard-sync` to all connected socket clients
- Accepts incoming `clipboard-sync` events from clients and writes to the Mac clipboard (with echo prevention)
- Maintains a 20-item ring buffer of clipboard history
- Adds a **Clipboard History** tray submenu — clicking any item pushes it to the Mac clipboard and broadcasts to all clients

## How it works

The Mac server acts as the hub. Apple Universal Clipboard already syncs iPhone↔Mac for free. This service extends that to Windows (and any other BB client) by bridging over the existing socket connection.

## Test plan

- [ ] Copy text on a connected Windows client — confirm it appears on the Mac clipboard
- [ ] Copy text on the Mac — confirm it broadcasts to connected clients
- [ ] Open the tray menu — confirm Clipboard History submenu shows recent items
- [ ] Click a history item — confirm it pushes to Mac clipboard and to all connected clients
- [ ] Verify echo prevention: server-written clipboard content is not immediately re-broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)