### PR TITLE
fix: cache native contact lookups so the synchronous getAllContacts() can't block the event loop (#811)

### DIFF
--- a/packages/server/src/server/api/lib/ContactsLib.ts
+++ b/packages/server/src/server/api/lib/ContactsLib.ts
@@ -28,6 +28,16 @@ export class ContactsLib {
         'socialProfiles'
     ];
 
+    // In-memory cache of native contact results, keyed by the requested extra-prop set.
+    // node-mac-contacts' getAllContacts() is SYNCHRONOUS and, when images/thumbnails are
+    // requested, marshals avatar data for every contact — multi-second on large address
+    // books, which blocks the Node event loop and stalls all other HTTP requests (including
+    // the socket health probe), causing clients to drop and reconnect. Caching makes repeat
+    // calls instant so the synchronous native call stays off the hot path.
+    private static cache: Map<string, any[]> = new Map();
+    private static cacheLoadedAt = 0;
+    private static readonly cacheTtlMs = 5 * 60 * 1000; // safety net; also cleared on OS contact-change
+
     static async requestAccess() {
         if (!contacts) return "Unknown";
         return await contacts.requestAccess();
@@ -46,6 +56,18 @@ export class ContactsLib {
     static getAllContacts(extraProps: string[] = []) {
         if (!contacts) return [];
 
+        // Drop the cache after the TTL as a safety net in case an OS change event is missed.
+        if (ContactsLib.cacheLoadedAt && Date.now() - ContactsLib.cacheLoadedAt > ContactsLib.cacheTtlMs) {
+            ContactsLib.invalidateCache();
+        }
+
+        // Serve from cache when we already have a result for this exact prop set. This keeps
+        // the synchronous native call (and its event-loop block) off the hot path — repeat
+        // requests, e.g. clients re-fetching contacts-with-avatars on every reconnect, are free.
+        const key = JSON.stringify(extraProps.map(e => e.toLowerCase()).sort());
+        const cached = ContactsLib.cache.get(key);
+        if (cached) return cached;
+
         // If it's the first load, we need to load all available info.
         // And also listen for changes so we can reload all the info again.
         if (isFirstLoad) {
@@ -54,7 +76,15 @@ export class ContactsLib {
             ContactsLib.listenForChanges();
         }
 
-        return contacts.getAllContacts(extraProps);
+        const result = contacts.getAllContacts(extraProps);
+        ContactsLib.cache.set(key, result);
+        if (!ContactsLib.cacheLoadedAt) ContactsLib.cacheLoadedAt = Date.now();
+        return result;
+    }
+
+    static invalidateCache() {
+        ContactsLib.cache.clear();
+        ContactsLib.cacheLoadedAt = 0;
     }
 
     static listenForChanges() {
@@ -63,6 +93,7 @@ export class ContactsLib {
         contacts.listener.once('contact-changed', (_: string) => {
             Server().log("Detected contact change, queueing full reload...", "debug");
             isFirstLoad = true;
+            ContactsLib.invalidateCache();
             contacts.listener.remove();
         });
     }


### PR DESCRIPTION
## What

Cache `ContactsLib.getAllContacts()` results so repeat calls don't re-run the synchronous `node-mac-contacts` native lookup. Fixes #811.

## Why

`ContactsLib.getAllContacts()` calls `node-mac-contacts`' **synchronous** `getAllContacts(extraProps)` on every request. When images/thumbnails are requested (`extraProperties=avatar` → `contactImage`/`contactThumbnailImage`), it marshals avatar data for every contact — multi-second on large address books. Because the call is synchronous, it **blocks the Node event loop** for its full duration, stalling every other in-flight HTTP request — including the socket health/reachability probe. Clients (observed: Windows desktop) treat the missed probe as the server being unreachable, drop the socket, reconnect, and re-request contacts-with-avatars — re-triggering the block. The result is a reconnect loop that surfaces as the client stuck on "connecting".

The file already had the *intent* to cache (an `isFirstLoad` flag + a `contact-changed` listener) but never stored the loaded result, so every call re-paid the full native cost.

Measured on a live 1.9.9 server (~2,500 contacts, macOS 15.7.7, Messages 14): `GET /api/v1/contact?extraProperties=avatar` ≈ 4.3–5.7 s, and a `GET /api/v1/ping` fired during it was delayed ~4.8 s (vs ~2 ms idle), confirming the event-loop block. Plain `/contact` (no avatars) and `/server/statistics/*` were single-digit ms.

## How

- Cache the native result in a `Map` keyed by the normalized + sorted requested extra-prop set.
- Serve repeat requests from cache, keeping the synchronous native call off the hot path.
- Invalidate on the existing `contact-changed` OS listener (immediate) plus a 5-minute TTL safety net for any missed event.

A client's reconnect re-fetch now hits the cache and returns instantly, so the probe no longer times out and the loop stops. The first (cold) load still runs once; moving it off-thread (worker) is a possible follow-up, kept out of scope to stay minimal.

## Testing

The block was measured on a live 1.9.9 server as described above. The change is localized to `ContactsLib` and reuses the existing change-listener. I did not run a full end-to-end build against a production database (to avoid standing up a second server instance alongside a live one) — happy to adjust the TTL or approach per maintainer preference.

## Related

Sibling of #812 — the statistics endpoints share the same synchronous-on-main-thread + no-cache pattern (`better-sqlite3` `COUNT(*)`).
