### PR TITLE
Add missing message attachments from attributed body

### DIFF
--- a/packages/server/src/server/databases/imessage/index.ts
+++ b/packages/server/src/server/databases/imessage/index.ts
@@ -152,7 +152,7 @@ export class MessageRepository extends Loggable {
      * @param attachmentGuid A specific attachment identifier to get
      * @param withMessages Whether to include the participants or not
      */
-    async getAttachment(attachmentGuid: string, withMessages = false) {
+    async getAttachment(attachmentGuid: string, withMessages = false): Promise<Attachment | null> {
         const query = this.db.getRepository(Attachment).createQueryBuilder("attachment");
 
         if (withMessages) query.leftJoinAndSelect("attachment.messages", "message");
@@ -162,7 +162,7 @@ export class MessageRepository extends Loggable {
         // Original GUIDs can also be prefixed with at_x_ or p:/.
         const lookupGuids = [attachmentGuid];
         if (attachmentGuid.length > 36) {
-            lookupGuids.push(attachmentGuid.substring(attachmentGuid.length - 36));
+            lookupGuids.push(this.normalizeAttachmentGuid(attachmentGuid));
         }
 
         for (const lookupGuid of lookupGuids) {
@@ -202,6 +202,7 @@ export class MessageRepository extends Loggable {
         query.andWhere("message.guid = :guid", { guid });
 
         const message = await query.getOne();
+        if (withAttachments && message) await this.addMissingAttachmentsFromAttributedBody([message]);
         return message;
     }
 
@@ -302,7 +303,9 @@ export class MessageRepository extends Loggable {
         query.skip(offset);
         query.take(limit);
 
-        return await query.getManyAndCount();
+        const [messages, totalCount] = await query.getManyAndCount();
+        if (withAttachments) await this.addMissingAttachmentsFromAttributedBody(messages);
+        return [messages, totalCount];
     }
 
     /**
@@ -459,7 +462,59 @@ export class MessageRepository extends Loggable {
         query.skip(offset);
         query.take(limit);
 
-        return await query.getMany();
+        const messages = await query.getMany();
+        if (withAttachments) await this.addMissingAttachmentsFromAttributedBody(messages);
+        return messages;
+    }
+
+    private normalizeAttachmentGuid(guid: string): string {
+        return guid.slice(-36).toLowerCase();
+    }
+
+    private getAttributedBodyAttachmentGuids(message: Message): string[] {
+        const guids = new Set<string>();
+        for (const item of message.attributedBody ?? []) {
+            for (const run of item?.runs ?? []) {
+                const guid = run?.attributes?.__kIMFileTransferGUIDAttributeName;
+                if (typeof guid === "string" && guid.length > 0) guids.add(guid);
+            }
+        }
+
+        return Array.from(guids);
+    }
+
+    private async addMissingAttachmentsFromAttributedBody(messages: Message[]): Promise<void> {
+        const attachmentCache = new Map<string, Attachment | null>();
+
+        for (const message of messages) {
+            const guids = this.getAttributedBodyAttachmentGuids(message);
+            if (guids.length === 0) continue;
+
+            if (!message.attachments) message.attachments = [];
+
+            for (const guid of guids) {
+                const normalizedGuid = this.normalizeAttachmentGuid(guid);
+                const existing = message.attachments.some(attachment => {
+                    return [attachment.guid, attachment.originalGuid].some(attachmentGuid => {
+                        return (
+                            typeof attachmentGuid === "string" &&
+                            this.normalizeAttachmentGuid(attachmentGuid) === normalizedGuid
+                        );
+                    });
+                });
+                if (existing) continue;
+
+                if (!attachmentCache.has(normalizedGuid)) {
+                    attachmentCache.set(normalizedGuid, await this.getAttachment(guid));
+                }
+
+                const attachment = attachmentCache.get(normalizedGuid);
+                if (!attachment) continue;
+
+                const alreadyAdded = message.attachments.some(item => item.ROWID === attachment.ROWID);
+                if (!alreadyAdded) message.attachments.push(attachment);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Disclosure: This change was prepared with Codex assistance.

## Summary

This adds missing message attachments from file-transfer GUIDs found in `attributedBody` when those attachments were not loaded through the normal attachment join.

## Observed impact

This was seen while using BlueBubbles Server `1.9.9` as the local backend for a self-hosted Beeper iMessage bridge on macOS Sequoia `15.7.7` (`24G720`). In an iMessage group chat, image messages were not loading in Beeper because the BlueBubbles message/chat APIs returned `attachments: []` for affected messages.

For the affected message, the attachment GUID was still present in `attributedBody` under `__kIMFileTransferGUIDAttributeName`, and BlueBubbles could resolve that GUID through the existing attachment endpoint. The media existed, but API consumers did not see it in the message payload.

## Related Issue

Fixes #816.


## macOS version comparison

A comparison against a newer macOS sample (`26.5.1`, build `25F80`) did not reproduce the missing-join shape: the same class of inbound group-chat image message had both a `message_attachment_join` row and a file-transfer GUID in `attributedBody`, and BlueBubbles returned the attachment through HTTP and Socket.IO.

The affected macOS `15.7.7` sample differed by retaining the resolvable file-transfer GUID in `attributedBody` while omitting the normal `message_attachment_join` relationship. This change handles that recoverable fallback case and is a no-op when the join already loads the attachment.

## Changes

- When attachments are requested, add any attachments referenced by file-transfer GUIDs in `attributedBody` that are not already present on the message.
- Reuse the existing `getAttachment()` lookup so attachment GUID handling stays in one place.
- Avoid adding duplicates when attachments were already loaded through `message_attachment_join`.

## Tested

Tested against the local BlueBubbles data on the same Mac where the Beeper bridge issue was reproduced.

- Baseline installed BlueBubbles `1.9.9` on `127.0.0.1:1234`: the known affected message returned `attachments: []`.
- Patched BlueBubbles server from this branch: the same direct message API call returned the expected JPEG attachment.
- Patched chat pagination API for the affected group chat: the known message was present and returned the same expected attachment.
- Patched Socket.IO message query and live event paths also returned the expected attachment for the affected message shape.
- Replaced the local BlueBubbles app with the patched build and confirmed the self-hosted Beeper `sh-imessage` bridge queried the patched BlueBubbles endpoint directly.

Validation commands run:

- `git diff --check`
- `npm ci --ignore-scripts`
- `../../node_modules/.bin/eslint --ext=ts src/server/databases/imessage/index.ts --quiet`
- `npm run build` from `packages/server`

Full `npm run lint -- --quiet` still fails on unrelated pre-existing lint errors outside this change.



