### PR TITLE
Add polling fallback for iMessage listener

### DIFF
--- a/packages/server/src/server/databases/imessage/listeners/IMessageListener.ts
+++ b/packages/server/src/server/databases/imessage/listeners/IMessageListener.ts
@@ -27,19 +27,39 @@ export class IMessageListener extends Loggable {
 
     lastCheck = 0;
 
-    constructor({ filePaths, repo, cache }: { filePaths: string[], repo: MessageRepository, cache: IMessageCache }) {
+    pollIntervalMs: number;
+
+    pollTimer: NodeJS.Timeout | null = null;
+
+    constructor({
+        filePaths,
+        repo,
+        cache,
+        pollIntervalMs = 1000
+    }: {
+        filePaths: string[],
+        repo: MessageRepository,
+        cache: IMessageCache,
+        pollIntervalMs?: number
+    }) {
         super();
 
         this.filePaths = filePaths;
         this.repo = repo;
         this.pollers = [];
         this.cache = cache;
+        this.pollIntervalMs = pollIntervalMs;
         this.stopped = false;
         this.processLock = new Sema(1);
     }
 
     stop() {
         this.stopped = true;
+        if (this.pollTimer) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+        }
+        this.watcher?.stop();
         this.removeAllListeners();
     }
 
@@ -79,6 +99,20 @@ export class IMessageListener extends Loggable {
         });
 
         this.watcher.start();
+        this.startPollTimer();
+    }
+
+    startPollTimer() {
+        if (this.pollTimer || this.pollIntervalMs <= 0) return;
+
+        this.pollTimer = setInterval(async () => {
+            await this.handleChangeEvent({
+                filePath: "poll-interval",
+                prevStat: null,
+                currentStat: null
+            });
+        }, this.pollIntervalMs);
+        this.pollTimer.unref?.();
     }
 
     @DebounceSubsequentWithWait('IMessageListener.handleChangeEvent', 500)

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -1276,7 +1276,8 @@ class BlueBubblesServer extends EventEmitter {
                 this.iMessageRepo.dbPathWal
             ],
             cache,
-            repo: this.iMessageRepo
+            repo: this.iMessageRepo,
+            pollIntervalMs: this.repo.getConfig("db_poll_interval") as number
         });
 
         this.iMessageListener.addPoller(new MessagePoller(this.iMessageRepo, cache));


### PR DESCRIPTION
## Summary

Adds a periodic polling fallback to the iMessage database listener while keeping the existing `fs.watch` path for low-latency delivery.

The listener already had a `db_poll_interval` config default, but the active listener path only reacted to filesystem change events for `chat.db` / `chat.db-wal`. On macOS, those events can be missed or delayed even when Messages has committed new rows. When that happens, BlueBubbles does not emit `new-message` and no FCM notification is sent until a client later runs an incremental sync.

## What changed

- Adds `pollIntervalMs` and a timer to `IMessageListener`.
- Reuses the existing debounced `handleChangeEvent` path so watcher events and interval polls share the same lock, lookback, cache trimming, and duplicate-event protection.
- Clears the interval and stops the watcher in `stop()`.
- Wires the interval to existing `db_poll_interval` config.

## Local verification

Reproduced on macOS with an Android BlueBubbles client:

1. A self-message appeared in `~/Library/Messages/chat.db`, but the server did not log `New Message` or send FCM until the Android app later queried `/api/v1/message/query`.
2. After this patch and repacking the local app, a new self-message produced:
   - server log: `New Message from +*******9008, "Hello"`
   - server log: `[FCMService] Sending FCM notification (Priority: high) to 1 device(s)`
   - Android log: `Received event of type new-message from Socket.io`
   - Android log: `Received new message of type new-message from FCM`
   - Android active notification on `com.bluebubbles.new_messages` with tag `com.bluebubbles.messaging.NEW_MESSAGE_NOTIFICATION`.

Build verification:

```bash
cd packages/server
npm run build
```

This completed successfully.
