### PR TITLE
Fix NotificationCenter database path on newer macOS

### DIFF
--- a/packages/server/src/server/databases/notificationCenter/NotiicationCenterRepository.ts
+++ b/packages/server/src/server/databases/notificationCenter/NotiicationCenterRepository.ts
@@ -1,4 +1,6 @@
 import fs from "fs";
+import os from "os";
+import path from "path";
 import { Brackets, DataSource } from "typeorm";
 import { Record } from "./entity/Record";
 import { App } from "./entity/App";
@@ -36,8 +38,11 @@ class NotificationCenterDatabase {
     }
 
     async getDbPath(): Promise<string> {
+        const usernotedPath = path.join(os.homedir(), "Library", "Group Containers", "group.com.apple.usernoted", "db2", "db");
+        if (fs.existsSync(usernotedPath)) return usernotedPath;
+
         const basePath = await FileSystem.getUserConfDir();
-        return `${basePath}com.apple.notificationcenter/db2/db`;
+        return path.join(basePath, "com.apple.notificationcenter", "db2", "db");
     }
 
     async dbExists(): Promise<boolean> {
@@ -54,7 +59,7 @@ class NotificationCenterDatabase {
 
         // Check if the DB path exists
         const dbPath = await this.getDbPath();
-        if (!this.dbExists()) {
+        if (!await this.dbExists()) {
             throw new Error("NotificationCenter database does not exist!");
         }
 


### PR DESCRIPTION
## Summary
- Prefer the newer macOS `group.com.apple.usernoted` NotificationCenter database path when it exists.
- Fall back to the legacy `com.apple.notificationcenter` database path.
- Await the existing async DB existence check so startup reports missing notification DBs correctly.

## Schema verification
- Verified on macOS 26 that `~/Library/Group Containers/group.com.apple.usernoted/db2/db` contains the same `record` and `app` table shape expected by the existing TypeORM entities.
- `record` columns: `rec_id`, `app_id`, `uuid`, `data`, `request_date`, `request_last_date`, `delivered_date`, `presented`, `style`, `snooze_fire_date`.
- `app` columns: `app_id`, `identifier`, `badge`.
- Smoke-queried real rows from the new DB path, including `com.apple.mobilesms`.

## Testing
- Ran `git diff --check origin/development...HEAD`.
- Confirmed `origin/development` does not currently contain the `group.com.apple.usernoted` path fix.