### PR TITLE
Allow attachment chat GUID via query fallback

### DIFF
--- a/packages/server/src/server/api/http/api/v1/validators/messageValidator.ts
+++ b/packages/server/src/server/api/http/api/v1/validators/messageValidator.ts
@@ -155,6 +155,17 @@ export class MessageValidator {
     };
 
     static async validateAttachment(ctx: RouterContext, next: Next) {
+        // curl -F treats semicolons as field options and can truncate chatGuid.
+        // Accept a query fallback when the body is missing or is its truncated prefix.
+        const bodyChatGuid = ctx.request.body.chatGuid;
+        const queryChatGuid = ctx.request.query.chatGuid;
+        if (
+            typeof queryChatGuid === "string" &&
+            (bodyChatGuid == null || (typeof bodyChatGuid === "string" && queryChatGuid.startsWith(`${bodyChatGuid};`)))
+        ) {
+            ctx.request.body.chatGuid = queryChatGuid;
+        }
+
         const { files } = ctx.request;
         const { tempGuid, method, isAudioMessage, effectId, subject, selectedMessageGuid } = ValidateInput(
             ctx.request?.body,


### PR DESCRIPTION
## What changed

Allow `POST /api/v1/message/attachment` to use a string `chatGuid` query parameter when the multipart body omits the field or contains a semicolon-truncated prefix of the query value.

The existing multipart body remains authoritative for complete or conflicting values. The query parameter is copied into the request body before the existing attachment validation runs, so the same `required|string` validation and downstream routing continue to apply.

## Why

Addresses the workaround requested in #804. The truncation is reproducible before the request reaches BlueBubbles: curl's `-F` parser treats semicolons as form-field option delimiters, so `-F 'chatGuid=iMessage;-;+15551234567'` sends only `iMessage`. `--form-string` sends the full value, but accepting the query parameter provides a backwards-compatible path for affected clients.

Example query value: `chatGuid=iMessage%3B-%3B%2B15551234567`. The `+` is encoded as `%2B` so query parsing does not turn it into a space.

## Impact

- Existing clients that send a complete multipart `chatGuid` are unchanged.
- A query-only `chatGuid` now passes through the existing validator.
- A query `chatGuid` can repair a body value that is its semicolon-truncated prefix.
- Conflicting complete body/query values keep the multipart body value.

## Validation

- Reproduced curl `-F` truncation against an independent HTTP echo endpoint.
- Confirmed `curl --form-string` preserves the full GUID.
- Exercised query-only, truncated-prefix, complete-conflict, missing-query, and invalid-body branch cases with assertions.
- Ran Prettier 2.8.8 with the repository config.
- Ran `git diff --check`.

A macOS/iMessage end-to-end test was not available in this environment.
