### PR TITLE
Fix headless startup window minimization

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,7 @@
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
+        "test:headless-window": "node ./scripts/test-headless-window.js",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -9,10 +9,10 @@
     },
     "description": "BlueBubbles Server is the app that powers the BlueBubbles app ecosystem",
     "scripts": {
+        "test:headless-window": "node ./scripts/test-headless-window.js",
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
-        "test:headless-window": "node ./scripts/test-headless-window.js",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/scripts/test-headless-window.js
+++ b/packages/server/scripts/test-headless-window.js
@@ -1,0 +1,40 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const typescript = require("typescript");
+
+const sourcePath = path.resolve(__dirname, "../src/server/utils/WindowUtils.ts");
+const sourceCode = fs.readFileSync(sourcePath, "utf8");
+const compiledCode = typescript.transpileModule(sourceCode, {
+    compilerOptions: {
+        module: typescript.ModuleKind.CommonJS,
+        target: typescript.ScriptTarget.ES2020
+    },
+    fileName: sourcePath
+}).outputText;
+
+const loadedModule = { exports: {} };
+const executeModule = new Function("require", "module", "exports", compiledCode);
+executeModule(require, loadedModule, loadedModule.exports);
+
+const { minimizeWindowIfRequested } = loadedModule.exports;
+let minimizeCalls = 0;
+const window = {
+    minimize: () => {
+        minimizeCalls += 1;
+    }
+};
+
+assert.doesNotThrow(
+    () => minimizeWindowIfRequested(true, null),
+    "headless startup must not minimize a missing BrowserWindow"
+);
+assert.equal(minimizeCalls, 0);
+
+minimizeWindowIfRequested(false, window);
+assert.equal(minimizeCalls, 0, "a visible window must remain unchanged when start minimized is disabled");
+
+minimizeWindowIfRequested(true, window);
+assert.equal(minimizeCalls, 1, "a visible window must still minimize when start minimized is enabled");
+
+console.log("Headless window minimization checks passed.");

--- a/packages/server/scripts/test-headless-window.js
+++ b/packages/server/scripts/test-headless-window.js
@@ -25,16 +25,19 @@ const window = {
     }
 };
 
-assert.doesNotThrow(
-    () => minimizeWindowIfRequested(true, null),
-    "headless startup must not minimize a missing BrowserWindow"
-);
+let didMinimize;
+assert.doesNotThrow(() => {
+    didMinimize = minimizeWindowIfRequested(true, null);
+}, "headless startup must not minimize a missing BrowserWindow");
+assert.equal(didMinimize, false, "headless startup must report that no window was minimized");
 assert.equal(minimizeCalls, 0);
 
-minimizeWindowIfRequested(false, window);
+didMinimize = minimizeWindowIfRequested(false, window);
+assert.equal(didMinimize, false, "disabled start minimized must report that no window was minimized");
 assert.equal(minimizeCalls, 0, "a visible window must remain unchanged when start minimized is disabled");
 
-minimizeWindowIfRequested(true, window);
+didMinimize = minimizeWindowIfRequested(true, window);
+assert.equal(didMinimize, true, "enabled start minimized must report a successful minimization");
 assert.equal(minimizeCalls, 1, "a visible window must still minimize when start minimized is enabled");
 
 console.log("Headless window minimization checks passed.");

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -72,6 +72,7 @@ import { obfuscatedHandle } from "./utils/StringUtils";
 import { AutoStartMethods } from "./databases/server/constants";
 import { MacOsInterface } from "./api/interfaces/macosInterface";
 import { ZrokManager } from "./managers/zrokManager";
+import { minimizeWindowIfRequested } from "./utils/WindowUtils";
 
 const findProcess = require("find-process");
 
@@ -790,9 +791,7 @@ class BlueBubblesServer extends EventEmitter {
 
         // Start minimized if enabled
         const startMinimized = Server().repo.getConfig("start_minimized") as boolean;
-        if (startMinimized) {
-            this.window.minimize();
-        }
+        minimizeWindowIfRequested(startMinimized, this.window);
 
         // Disable the encryp coms setting if it's enabled.
         // This is a temporary fix until the android client supports it again.

--- a/packages/server/src/server/index.ts
+++ b/packages/server/src/server/index.ts
@@ -791,7 +791,10 @@ class BlueBubblesServer extends EventEmitter {
 
         // Start minimized if enabled
         const startMinimized = Server().repo.getConfig("start_minimized") as boolean;
-        minimizeWindowIfRequested(startMinimized, this.window);
+        const didMinimizeWindow = minimizeWindowIfRequested(startMinimized, this.window);
+        if (startMinimized && !didMinimizeWindow) {
+            this.logger.debug("Skipping start-minimized behavior because headless mode has no BrowserWindow.");
+        }
 
         // Disable the encryp coms setting if it's enabled.
         // This is a temporary fix until the android client supports it again.

--- a/packages/server/src/server/utils/WindowUtils.ts
+++ b/packages/server/src/server/utils/WindowUtils.ts
@@ -1,0 +1,7 @@
+import type { BrowserWindow } from "electron";
+
+export const minimizeWindowIfRequested = (startMinimized: boolean, window: BrowserWindow | null): void => {
+    if (startMinimized && window) {
+        window.minimize();
+    }
+};

--- a/packages/server/src/server/utils/WindowUtils.ts
+++ b/packages/server/src/server/utils/WindowUtils.ts
@@ -1,7 +1,8 @@
 import type { BrowserWindow } from "electron";
 
-export const minimizeWindowIfRequested = (startMinimized: boolean, window: BrowserWindow | null): void => {
-    if (startMinimized && window) {
-        window.minimize();
-    }
+export const minimizeWindowIfRequested = (startMinimized: boolean, window: BrowserWindow | null): boolean => {
+    if (!startMinimized || !window) return false;
+
+    window.minimize();
+    return true;
 };


### PR DESCRIPTION
## Summary

- Skip window minimization when headless startup intentionally has no `BrowserWindow`.
- Preserve the existing start-minimized behavior whenever a window is available.
- Add a focused regression check for the headless/null-window, disabled, and ordinary minimization paths.

## Root cause

Headless mode returns from `AppWindow.build()` without creating a `BrowserWindow`. During server initialization, `preChecks()` still reads the independent `start_minimized` setting and unconditionally calls `this.window.minimize()`. When both settings are enabled, the null window dereference rejects startup before the HTTP server begins listening.

The minimization decision now goes through a small null-safe helper. This keeps the normal GUI behavior unchanged while making the headless combination a no-op.

## User impact

BlueBubbles can start headlessly from SSH, a LaunchAgent, or another session without a WindowServer connection even when `start_minimized` remains enabled. Existing GUI launches with start-minimized enabled still minimize their window.

## Validation

Passed:

- `npm --workspace @bluebubbles/server run test:headless-window`
- Prettier check for all changed files
- Targeted ESLint for `src/server/index.ts` and `src/server/utils/WindowUtils.ts`
- Targeted TypeScript `--noEmit` check for `WindowUtils.ts`
- `git diff --check`

The full repository checks still expose unrelated errors in unchanged `origin/development` files:

- Full server lint: existing `max-len` errors in `src/server/api/privateApi/modes/dylibPlugins/index.ts` lines 143 and 158.
- Production server build: existing `NodeJS.Timer` / `clearInterval` type mismatch in `src/server/lib/ScheduledService.ts` line 39.

Fixes #789.

Related: #733.
