### PR TITLE
Resolve Tahoe fallback service from chat metadata

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,7 @@
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
+        "test:tahoe-fallback-service": "node --test test/tahoeFallbackService.test.cjs",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,9 +10,9 @@
     "description": "BlueBubbles Server is the app that powers the BlueBubbles app ecosystem",
     "scripts": {
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
+        "test:tahoe-fallback-service": "node --test test/tahoeFallbackService.test.cjs",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
-        "test:tahoe-fallback-service": "node --test test/tahoeFallbackService.test.cjs",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/src/server/api/apple/actions.ts
+++ b/packages/server/src/server/api/apple/actions.ts
@@ -91,7 +91,24 @@ export class ActionHandler {
             try {
                 // Generate the new send script
                 log.debug(`Sending AppleScript text using fallback script...`);
-                messageScript = sendMessageFallback(chatGuid, message ?? "", theAttachment);
+                let resolvedService: string = null;
+                if (chatGuid.startsWith("any;")) {
+                    try {
+                        const [chats] = await Server().iMessageRepo.getChats({
+                            chatGuid,
+                            withParticipants: false,
+                            limit: 1
+                        });
+                        resolvedService = chats[0]?.serviceName ?? null;
+                    } catch (serviceError: any) {
+                        log.debug(
+                            `Failed to resolve the fallback chat service: ` +
+                                `${serviceError?.message ?? String(serviceError)}`
+                        );
+                    }
+                }
+
+                messageScript = sendMessageFallback(chatGuid, message ?? "", theAttachment, resolvedService);
                 await FileSystem.executeAppleScript(messageScript);
             } catch (ex: any) {
                 error = ex;

--- a/packages/server/src/server/api/apple/actions.ts
+++ b/packages/server/src/server/api/apple/actions.ts
@@ -100,11 +100,8 @@ export class ActionHandler {
                             limit: 1
                         });
                         resolvedService = chats[0]?.serviceName ?? null;
-                    } catch (serviceError: any) {
-                        log.debug(
-                            `Failed to resolve the fallback chat service: ` +
-                                `${serviceError?.message ?? String(serviceError)}`
-                        );
+                    } catch {
+                        log.debug("Failed to resolve the fallback chat service; using the legacy iMessage default.");
                     }
                 }
 

--- a/packages/server/src/server/api/apple/actions.ts
+++ b/packages/server/src/server/api/apple/actions.ts
@@ -91,7 +91,7 @@ export class ActionHandler {
             try {
                 // Generate the new send script
                 log.debug(`Sending AppleScript text using fallback script...`);
-                let resolvedService: string = null;
+                let resolvedService: string | null = null;
                 if (chatGuid.startsWith("any;")) {
                     try {
                         const [chats] = await Server().iMessageRepo.getChats({
@@ -101,7 +101,9 @@ export class ActionHandler {
                         });
                         resolvedService = chats[0]?.serviceName ?? null;
                     } catch {
-                        log.debug("Failed to resolve the fallback chat service; using the legacy iMessage default.");
+                        log.debug(
+                            "Failed to resolve the fallback chat service; the fallback message will not be sent."
+                        );
                     }
                 }
 

--- a/packages/server/src/server/api/apple/scripts.ts
+++ b/packages/server/src/server/api/apple/scripts.ts
@@ -64,8 +64,9 @@ const getServiceFromInput = (value: string) => {
     // so we should default to iMessage
     if (valSplit.length <= 1) return "iMessage";
 
-    // Otherwise, return the "first" index in the array,
-    return valSplit[0];
+    // Tahoe uses "any" for iMessage chat GUIDs, but Messages AppleScript requires a concrete service type.
+    const service = valSplit[0];
+    return service === "any" ? "iMessage" : service;
 };
 
 /**

--- a/packages/server/src/server/api/apple/scripts.ts
+++ b/packages/server/src/server/api/apple/scripts.ts
@@ -15,7 +15,7 @@ const buildServiceScript = (inputService: string) => {
         theService = `"${theService}"`;
     }
 
-    const svcClass = isMinVentura ? "account" : "service";
+    const svcClass = isMinVentura ? 'account' : 'service';
 
     let serviceScript = `set targetService to 1st ${svcClass} whose service type = ${theService}`;
     if (!isMinBigSur && theService !== "iMessage") {

--- a/packages/server/src/server/api/apple/scripts.ts
+++ b/packages/server/src/server/api/apple/scripts.ts
@@ -56,7 +56,7 @@ const getAddressFromInput = (value: string) => {
     return valSplit[valSplit.length - 1];
 };
 
-const getServiceFromInput = (value: string, resolvedService: string = null) => {
+const getServiceFromInput = (value: string, resolvedService: string | null = null) => {
     // This should always produce an array of minimum length, 1
     const valSplit = value.split(";");
 
@@ -69,7 +69,9 @@ const getServiceFromInput = (value: string, resolvedService: string = null) => {
     if (service !== "any") return service;
 
     const supportedServices = ["iMessage", "SMS", "RCS"];
-    return supportedServices.includes(resolvedService) ? resolvedService : "iMessage";
+    if (resolvedService && supportedServices.includes(resolvedService)) return resolvedService;
+
+    throw new Error("Unable to resolve a supported Messages service for this chat; the fallback message was not sent.");
 };
 
 /**
@@ -205,7 +207,7 @@ export const sendMessageFallback = (
     chatGuid: string,
     message: string,
     attachment: string,
-    resolvedService: string = null
+    resolvedService: string | null = null
 ) => {
     if (!chatGuid || (!message && !attachment)) return null;
 

--- a/packages/server/src/server/api/apple/scripts.ts
+++ b/packages/server/src/server/api/apple/scripts.ts
@@ -15,7 +15,7 @@ const buildServiceScript = (inputService: string) => {
         theService = `"${theService}"`;
     }
 
-    const svcClass = isMinVentura ? 'account' : 'service';
+    const svcClass = isMinVentura ? "account" : "service";
 
     let serviceScript = `set targetService to 1st ${svcClass} whose service type = ${theService}`;
     if (!isMinBigSur && theService !== "iMessage") {
@@ -56,7 +56,7 @@ const getAddressFromInput = (value: string) => {
     return valSplit[valSplit.length - 1];
 };
 
-const getServiceFromInput = (value: string) => {
+const getServiceFromInput = (value: string, resolvedService: string = null) => {
     // This should always produce an array of minimum length, 1
     const valSplit = value.split(";");
 
@@ -64,9 +64,12 @@ const getServiceFromInput = (value: string) => {
     // so we should default to iMessage
     if (valSplit.length <= 1) return "iMessage";
 
-    // Tahoe uses "any" for iMessage chat GUIDs, but Messages AppleScript requires a concrete service type.
+    // Tahoe uses "any" for multiple chat services, but Messages AppleScript requires a concrete service type.
     const service = valSplit[0];
-    return service === "any" ? "iMessage" : service;
+    if (service !== "any") return service;
+
+    const supportedServices = ["iMessage", "SMS", "RCS"];
+    return supportedServices.includes(resolvedService) ? resolvedService : "iMessage";
 };
 
 /**
@@ -198,7 +201,12 @@ export const sendMessage = (chatGuid: string, message: string, attachment: strin
     end tell`;
 };
 
-export const sendMessageFallback = (chatGuid: string, message: string, attachment: string) => {
+export const sendMessageFallback = (
+    chatGuid: string,
+    message: string,
+    attachment: string,
+    resolvedService: string = null
+) => {
     if (!chatGuid || (!message && !attachment)) return null;
 
     // Build the sending scripts
@@ -207,7 +215,7 @@ export const sendMessageFallback = (chatGuid: string, message: string, attachmen
 
     // Extract the address and service from the input address/GUID
     const address = getAddressFromInput(chatGuid);
-    const service = getServiceFromInput(chatGuid);
+    const service = getServiceFromInput(chatGuid, resolvedService);
 
     // If it starts with `chat`, it's a group chat, and we can't use this script for that
     if (address.startsWith("chat")) {

--- a/packages/server/test/tahoeFallbackService.test.cjs
+++ b/packages/server/test/tahoeFallbackService.test.cjs
@@ -30,6 +30,21 @@ const scripts = loadTypeScriptModule(scriptsPath, {
     "@server/helpers/utils": helpers,
     "@server/env": { isMinBigSur: true, isMinVentura: true }
 });
+const actionsPath = path.join(__dirname, "../src/server/api/apple/actions.ts");
+const loadActionHandler = ({ server, fileSystem, logger }) =>
+    loadTypeScriptModule(actionsPath, {
+        "@server": { Server: () => server },
+        "@server/fileSystem": { FileSystem: fileSystem },
+        "@server/types": {},
+        "@server/api/apple/scripts": scripts,
+        "../../types": {},
+        "../../helpers/utils": helpers,
+        "./mappings": { tapbackUIMap: {} },
+        "../interfaces/messageInterface": { MessageInterface: {} },
+        "../../lib/logging/Loggable": { getLogger: () => logger }
+    }).ActionHandler;
+const resolutionError =
+    "Unable to resolve a supported Messages service for this chat; the fallback message was not sent.";
 
 test("Tahoe any GUIDs use the service resolved from the matching chat", () => {
     const imessageScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "iMessage");
@@ -54,22 +69,101 @@ test("explicit service GUIDs and unqualified addresses preserve their existing b
 });
 
 test("unresolved or unsupported any GUID services fail closed", () => {
-    const expectedError =
-        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/;
-
-    assert.throws(() => scripts.sendMessageFallback("any;-;test-address", "test", null), expectedError);
-    assert.throws(() => scripts.sendMessageFallback("any;-;test-address", "test", null, "unknown"), expectedError);
+    assert.throws(() => scripts.sendMessageFallback("any;-;test-address", "test", null), {
+        message: resolutionError
+    });
+    assert.throws(() => scripts.sendMessageFallback("any;-;test-address", "test", null, "unknown"), {
+        message: resolutionError
+    });
 });
 
-test("ActionHandler passes the matching service and fails closed when lookup cannot resolve it", async () => {
+test("ActionHandler passes every supported service resolved from a Tahoe any chat", async () => {
     const executedScripts = [];
     const chatQueries = [];
-    const debugMessages = [];
+    let resolvedService;
     const server = {
         iMessageRepo: {
             getChats: async options => {
                 chatQueries.push(options);
-                return [[{ serviceName: "RCS" }], 1];
+                return [[{ serviceName: resolvedService }], 1];
+            }
+        }
+    };
+    const fileSystem = {
+        convertMp3ToCaf: async () => undefined,
+        executeAppleScript: async script => {
+            executedScripts.push(script);
+            if (script.includes("set targetChat to")) throw new Error("force fallback");
+        }
+    };
+    const logger = {
+        debug: () => undefined,
+        warn: () => undefined
+    };
+    const ActionHandler = loadActionHandler({ server, fileSystem, logger });
+    const supportedServices = ["iMessage", "SMS", "RCS"];
+
+    for (const service of supportedServices) {
+        resolvedService = service;
+        await ActionHandler.sendMessage("any;-;test-address", "test", null);
+        assert.match(executedScripts.at(-1), new RegExp(`service type = ${service}`));
+    }
+
+    assert.deepEqual(
+        chatQueries,
+        supportedServices.map(() => ({
+            chatGuid: "any;-;test-address",
+            withParticipants: false,
+            limit: 1
+        }))
+    );
+    assert.equal(executedScripts.length, supportedServices.length * 2);
+    assert.equal(
+        executedScripts.filter(script => script.includes("set targetBuddy to")).length,
+        supportedServices.length
+    );
+});
+
+test("ActionHandler does not query chat metadata for explicit service GUIDs", async () => {
+    const executedScripts = [];
+    let chatQueries = 0;
+    const server = {
+        iMessageRepo: {
+            getChats: async () => {
+                chatQueries += 1;
+                return [[{ serviceName: "iMessage" }], 1];
+            }
+        }
+    };
+    const fileSystem = {
+        convertMp3ToCaf: async () => undefined,
+        executeAppleScript: async script => {
+            executedScripts.push(script);
+            if (script.includes("set targetChat to")) throw new Error("force fallback");
+        }
+    };
+    const logger = {
+        debug: () => undefined,
+        warn: () => undefined
+    };
+    const ActionHandler = loadActionHandler({ server, fileSystem, logger });
+
+    for (const service of ["iMessage", "SMS", "RCS"]) {
+        await ActionHandler.sendMessage(`${service};-;test-address`, "test", null);
+        assert.match(executedScripts.at(-1), new RegExp(`service type = ${service}`));
+    }
+
+    assert.equal(chatQueries, 0);
+});
+
+test("ActionHandler fails closed without executing fallback when lookup cannot resolve a service", async () => {
+    const executedScripts = [];
+    const debugMessages = [];
+    const warnMessages = [];
+    const server = {
+        iMessageRepo: {
+            getChats: async () => {
+                throw new Error("private-database-details");
             }
         }
     };
@@ -82,62 +176,40 @@ test("ActionHandler passes the matching service and fails closed when lookup can
     };
     const logger = {
         debug: message => debugMessages.push(message),
-        warn: () => undefined
+        warn: message => warnMessages.push(message)
     };
-    const actionsPath = path.join(__dirname, "../src/server/api/apple/actions.ts");
-    const { ActionHandler } = loadTypeScriptModule(actionsPath, {
-        "@server": { Server: () => server },
-        "@server/fileSystem": { FileSystem: fileSystem },
-        "@server/types": {},
-        "@server/api/apple/scripts": scripts,
-        "../../types": {},
-        "../../helpers/utils": helpers,
-        "./mappings": { tapbackUIMap: {} },
-        "../interfaces/messageInterface": { MessageInterface: {} },
-        "../../lib/logging/Loggable": { getLogger: () => logger }
-    });
+    const ActionHandler = loadActionHandler({ server, fileSystem, logger });
+    const resolutionFailures = [
+        async () => {
+            throw new Error("private-database-details");
+        },
+        async () => [[], 0],
+        async () => [[{ serviceName: null }], 1],
+        async () => [[{ serviceName: "unknown" }], 1]
+    ];
 
-    await ActionHandler.sendMessage("any;-;test-address", "test", null);
+    for (const getChats of resolutionFailures) {
+        server.iMessageRepo.getChats = getChats;
+        await assert.rejects(() => ActionHandler.sendMessage("any;-;test-address", "test", null), {
+            message: resolutionError
+        });
+    }
 
-    assert.deepEqual(chatQueries, [
-        {
-            chatGuid: "any;-;test-address",
-            withParticipants: false,
-            limit: 1
-        }
-    ]);
-    assert.equal(executedScripts.length, 2);
-    assert.match(executedScripts[1], /service type = RCS/);
-
-    server.iMessageRepo.getChats = async () => {
-        throw new Error("private-database-details");
-    };
-    await assert.rejects(
-        () => ActionHandler.sendMessage("any;-;test-address", "test", null),
-        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/
+    assert.equal(executedScripts.length, resolutionFailures.length);
+    assert.equal(
+        executedScripts.every(script => script.includes("set targetChat to")),
+        true
     );
-
-    assert.equal(executedScripts.length, 3);
     assert.equal(
         debugMessages.some(message => message.includes("private-database-details")),
         false
+    );
+    assert.deepEqual(
+        warnMessages,
+        resolutionFailures.map(() => resolutionError)
     );
     assert.equal(
         debugMessages.includes("Failed to resolve the fallback chat service; the fallback message will not be sent."),
         true
     );
-
-    server.iMessageRepo.getChats = async () => [[], 0];
-    await assert.rejects(
-        () => ActionHandler.sendMessage("any;-;test-address", "test", null),
-        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/
-    );
-    assert.equal(executedScripts.length, 4);
-
-    server.iMessageRepo.getChats = async () => [[{ serviceName: "unknown" }], 1];
-    await assert.rejects(
-        () => ActionHandler.sendMessage("any;-;test-address", "test", null),
-        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/
-    );
-    assert.equal(executedScripts.length, 5);
 });

--- a/packages/server/test/tahoeFallbackService.test.cjs
+++ b/packages/server/test/tahoeFallbackService.test.cjs
@@ -1,0 +1,104 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const babel = require("@babel/core");
+
+const loadTypeScriptModule = (modulePath, overrides = {}) => {
+    const transformed = babel.transformFileSync(modulePath, {
+        presets: [
+            [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
+            require.resolve("@babel/preset-typescript")
+        ]
+    });
+    const loadedModule = { exports: {} };
+    const loadModule = new Function("module", "exports", "require", transformed.code);
+    const customRequire = request =>
+        Object.prototype.hasOwnProperty.call(overrides, request) ? overrides[request] : require(request);
+    loadModule(loadedModule, loadedModule.exports, customRequire);
+    return loadedModule.exports;
+};
+
+const helpers = {
+    escapeOsaExp: value => value,
+    getiMessageAddressFormat: value => value,
+    isEmpty: value => value == null || value.length === 0,
+    isNotEmpty: value => value != null && value.length > 0
+};
+const scriptsPath = path.join(__dirname, "../src/server/api/apple/scripts.ts");
+const scripts = loadTypeScriptModule(scriptsPath, {
+    "@server/fileSystem": { FileSystem: {} },
+    "@server/helpers/utils": helpers,
+    "@server/env": { isMinBigSur: true, isMinVentura: true }
+});
+
+test("Tahoe any GUIDs use the service resolved from the matching chat", () => {
+    const imessageScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "iMessage");
+    const rcsScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "RCS");
+
+    assert.match(imessageScript, /service type = iMessage/);
+    assert.match(rcsScript, /service type = RCS/);
+});
+
+test("explicit service GUIDs remain authoritative", () => {
+    const smsScript = scripts.sendMessageFallback("SMS;-;test-address", "test", null, "RCS");
+    const rcsScript = scripts.sendMessageFallback("RCS;-;test-address", "test", null, "iMessage");
+
+    assert.match(smsScript, /service type = SMS/);
+    assert.match(rcsScript, /service type = RCS/);
+});
+
+test("unresolved any GUIDs retain the legacy iMessage fallback", () => {
+    const fallbackScript = scripts.sendMessageFallback("any;-;test-address", "test", null);
+    const unknownServiceScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "unknown");
+
+    assert.match(fallbackScript, /service type = iMessage/);
+    assert.match(unknownServiceScript, /service type = iMessage/);
+});
+
+test("ActionHandler passes the matching chat service to the fallback script", async () => {
+    const executedScripts = [];
+    const chatQueries = [];
+    const server = {
+        iMessageRepo: {
+            getChats: async options => {
+                chatQueries.push(options);
+                return [[{ serviceName: "RCS" }], 1];
+            }
+        }
+    };
+    const fileSystem = {
+        convertMp3ToCaf: async () => undefined,
+        executeAppleScript: async script => {
+            executedScripts.push(script);
+            if (executedScripts.length === 1) throw new Error("force fallback");
+        }
+    };
+    const logger = {
+        debug: () => undefined,
+        warn: () => undefined
+    };
+    const actionsPath = path.join(__dirname, "../src/server/api/apple/actions.ts");
+    const { ActionHandler } = loadTypeScriptModule(actionsPath, {
+        "@server": { Server: () => server },
+        "@server/fileSystem": { FileSystem: fileSystem },
+        "@server/types": {},
+        "@server/api/apple/scripts": scripts,
+        "../../types": {},
+        "../../helpers/utils": helpers,
+        "./mappings": { tapbackUIMap: {} },
+        "../interfaces/messageInterface": { MessageInterface: {} },
+        "../../lib/logging/Loggable": { getLogger: () => logger }
+    });
+
+    await ActionHandler.sendMessage("any;-;test-address", "test", null);
+
+    assert.deepEqual(chatQueries, [
+        {
+            chatGuid: "any;-;test-address",
+            withParticipants: false,
+            limit: 1
+        }
+    ]);
+    assert.equal(executedScripts.length, 2);
+    assert.match(executedScripts[1], /service type = RCS/);
+});

--- a/packages/server/test/tahoeFallbackService.test.cjs
+++ b/packages/server/test/tahoeFallbackService.test.cjs
@@ -33,29 +33,35 @@ const scripts = loadTypeScriptModule(scriptsPath, {
 
 test("Tahoe any GUIDs use the service resolved from the matching chat", () => {
     const imessageScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "iMessage");
+    const smsScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "SMS");
     const rcsScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "RCS");
 
     assert.match(imessageScript, /service type = iMessage/);
-    assert.match(rcsScript, /service type = RCS/);
-});
-
-test("explicit service GUIDs remain authoritative", () => {
-    const smsScript = scripts.sendMessageFallback("SMS;-;test-address", "test", null, "RCS");
-    const rcsScript = scripts.sendMessageFallback("RCS;-;test-address", "test", null, "iMessage");
-
     assert.match(smsScript, /service type = SMS/);
     assert.match(rcsScript, /service type = RCS/);
 });
 
-test("unresolved any GUIDs retain the legacy iMessage fallback", () => {
-    const fallbackScript = scripts.sendMessageFallback("any;-;test-address", "test", null);
-    const unknownServiceScript = scripts.sendMessageFallback("any;-;test-address", "test", null, "unknown");
+test("explicit service GUIDs and unqualified addresses preserve their existing behavior", () => {
+    const imessageScript = scripts.sendMessageFallback("iMessage;-;test-address", "test", null, "SMS");
+    const smsScript = scripts.sendMessageFallback("SMS;-;test-address", "test", null, "RCS");
+    const rcsScript = scripts.sendMessageFallback("RCS;-;test-address", "test", null, "iMessage");
+    const unqualifiedScript = scripts.sendMessageFallback("test-address", "test", null);
 
-    assert.match(fallbackScript, /service type = iMessage/);
-    assert.match(unknownServiceScript, /service type = iMessage/);
+    assert.match(imessageScript, /service type = iMessage/);
+    assert.match(smsScript, /service type = SMS/);
+    assert.match(rcsScript, /service type = RCS/);
+    assert.match(unqualifiedScript, /service type = iMessage/);
 });
 
-test("ActionHandler passes the matching service and safely handles lookup failures", async () => {
+test("unresolved or unsupported any GUID services fail closed", () => {
+    const expectedError =
+        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/;
+
+    assert.throws(() => scripts.sendMessageFallback("any;-;test-address", "test", null), expectedError);
+    assert.throws(() => scripts.sendMessageFallback("any;-;test-address", "test", null, "unknown"), expectedError);
+});
+
+test("ActionHandler passes the matching service and fails closed when lookup cannot resolve it", async () => {
     const executedScripts = [];
     const chatQueries = [];
     const debugMessages = [];
@@ -71,7 +77,7 @@ test("ActionHandler passes the matching service and safely handles lookup failur
         convertMp3ToCaf: async () => undefined,
         executeAppleScript: async script => {
             executedScripts.push(script);
-            if (executedScripts.length % 2 === 1) throw new Error("force fallback");
+            if (script.includes("set targetChat to")) throw new Error("force fallback");
         }
     };
     const logger = {
@@ -106,16 +112,32 @@ test("ActionHandler passes the matching service and safely handles lookup failur
     server.iMessageRepo.getChats = async () => {
         throw new Error("private-database-details");
     };
-    await ActionHandler.sendMessage("any;-;test-address", "test", null);
+    await assert.rejects(
+        () => ActionHandler.sendMessage("any;-;test-address", "test", null),
+        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/
+    );
 
-    assert.equal(executedScripts.length, 4);
-    assert.match(executedScripts[3], /service type = iMessage/);
+    assert.equal(executedScripts.length, 3);
     assert.equal(
         debugMessages.some(message => message.includes("private-database-details")),
         false
     );
     assert.equal(
-        debugMessages.includes("Failed to resolve the fallback chat service; using the legacy iMessage default."),
+        debugMessages.includes("Failed to resolve the fallback chat service; the fallback message will not be sent."),
         true
     );
+
+    server.iMessageRepo.getChats = async () => [[], 0];
+    await assert.rejects(
+        () => ActionHandler.sendMessage("any;-;test-address", "test", null),
+        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/
+    );
+    assert.equal(executedScripts.length, 4);
+
+    server.iMessageRepo.getChats = async () => [[{ serviceName: "unknown" }], 1];
+    await assert.rejects(
+        () => ActionHandler.sendMessage("any;-;test-address", "test", null),
+        /Unable to resolve a supported Messages service for this chat; the fallback message was not sent/
+    );
+    assert.equal(executedScripts.length, 5);
 });

--- a/packages/server/test/tahoeFallbackService.test.cjs
+++ b/packages/server/test/tahoeFallbackService.test.cjs
@@ -55,9 +55,10 @@ test("unresolved any GUIDs retain the legacy iMessage fallback", () => {
     assert.match(unknownServiceScript, /service type = iMessage/);
 });
 
-test("ActionHandler passes the matching chat service to the fallback script", async () => {
+test("ActionHandler passes the matching service and safely handles lookup failures", async () => {
     const executedScripts = [];
     const chatQueries = [];
+    const debugMessages = [];
     const server = {
         iMessageRepo: {
             getChats: async options => {
@@ -70,11 +71,11 @@ test("ActionHandler passes the matching chat service to the fallback script", as
         convertMp3ToCaf: async () => undefined,
         executeAppleScript: async script => {
             executedScripts.push(script);
-            if (executedScripts.length === 1) throw new Error("force fallback");
+            if (executedScripts.length % 2 === 1) throw new Error("force fallback");
         }
     };
     const logger = {
-        debug: () => undefined,
+        debug: message => debugMessages.push(message),
         warn: () => undefined
     };
     const actionsPath = path.join(__dirname, "../src/server/api/apple/actions.ts");
@@ -101,4 +102,20 @@ test("ActionHandler passes the matching chat service to the fallback script", as
     ]);
     assert.equal(executedScripts.length, 2);
     assert.match(executedScripts[1], /service type = RCS/);
+
+    server.iMessageRepo.getChats = async () => {
+        throw new Error("private-database-details");
+    };
+    await ActionHandler.sendMessage("any;-;test-address", "test", null);
+
+    assert.equal(executedScripts.length, 4);
+    assert.match(executedScripts[3], /service type = iMessage/);
+    assert.equal(
+        debugMessages.some(message => message.includes("private-database-details")),
+        false
+    );
+    assert.equal(
+        debugMessages.includes("Failed to resolve the fallback chat service; using the legacy iMessage default."),
+        true
+    );
 });


### PR DESCRIPTION
## Summary

- resolve Tahoe `any` chat GUIDs to a concrete Messages service from the matching chat's metadata before generating the address-based AppleScript fallback
- accept only `iMessage`, `SMS`, or `RCS` as resolved services and fail closed when the lookup fails, returns no matching service, or returns an unsupported value
- keep service-lookup failure diagnostics generic instead of logging arbitrary database exception text
- preserve explicit service GUID prefixes, the unqualified-address iMessage default, and the primary chat-ID send path
- add focused regression coverage for service resolution, failure handling, and the `ActionHandler` fallback wiring

## Root cause

On macOS 26 Tahoe, `any` is a transport-agnostic chat GUID prefix observed across iMessage, SMS, and RCS chats. Messages AppleScript still requires a concrete service type, so interpolating `any` into the fallback script raises AppleScript error `-1700`. A hardcoded or unresolved `any` → `iMessage` mapping could misroute a non-iMessage conversation.

## Implementation

When the primary chat-ID send fails for an `any;...` GUID, `ActionHandler` queries the exact matching chat without loading participants and passes its `serviceName` to `sendMessageFallback()`. The script generator:

- honors explicit `iMessage`, `SMS`, and `RCS` GUID prefixes
- uses a resolved `iMessage`, `SMS`, or `RCS` value for `any` GUIDs
- throws a clear service-resolution error for an unresolved or unsupported `any` service before any fallback AppleScript is executed
- retains the existing iMessage default for unqualified addresses

If the metadata lookup itself fails, the debug log records only the generic failure decision, not the underlying exception text.

## Validation

Passed on the current head:

- `node --test test/tahoeFallbackService.test.cjs` — 6/6 tests
- targeted ESLint
- targeted Prettier for the newly changed code; the unchanged quote style in `scripts.ts` still matches the base branch
- `git diff --check`

The focused suite covers:

- resolved `any` iMessage, SMS, and RCS selection through both the script generator and `ActionHandler`
- authoritative explicit service GUIDs and proof that they bypass chat-metadata lookup
- the unqualified-address iMessage default
- lookup exceptions, empty results, null services, and unsupported services
- exact public errors, privacy-safe debug and warning logs, and proof that failure cases do not execute fallback AppleScript

Live validation on a SIP-enabled Tahoe host used the current production implementation without publishing identifiers or message content:

- a resolved `any` iMessage route recorded outgoing, sent, delivered, and no error
- a resolved `any` SMS route recorded outgoing, sent, and no error; no delivery receipt was available, so this is a dispatch pass
- a resolved `any` RCS route recorded outgoing, sent, delivered, and no error

Each live run forced the primary chat-ID path to fail, performed one exact-chat metadata lookup, executed one correctly resolved address-based fallback, and created one matching outgoing record. The failure-only cases are covered deterministically by the focused suite; no Messages database fault injection was needed. No recipient-confirmed delivery is claimed.

The production build reaches only the existing unrelated `ScheduledService.ts:39` `Timer`/`Timeout` type error.

Fixes #777
