### PR TITLE
Add typed, privacy-safe Google contact sync logging

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,7 @@
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
+        "test:contact-sync-logging": "node --test test/contactSyncLogging.test.cjs",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,8 +11,8 @@
     "scripts": {
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
-        "lint": "eslint --ext=jsx,js,tsx,ts src",
         "test:contact-sync-logging": "node --test test/contactSyncLogging.test.cjs",
+        "lint": "eslint --ext=jsx,js,tsx,ts src",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/src/server/api/interfaces/contactErrors.ts
+++ b/packages/server/src/server/api/interfaces/contactErrors.ts
@@ -1,0 +1,17 @@
+export const CONTACT_ERROR_CODES = {
+    MISSING_UPDATE_IDENTITY: "missing-contact-identity",
+    AMBIGUOUS_UPDATE_MATCH: "ambiguous-contact-match",
+    DUPLICATE_CONTACT: "duplicate-contact"
+} as const;
+
+export type ContactErrorCode = (typeof CONTACT_ERROR_CODES)[keyof typeof CONTACT_ERROR_CODES];
+
+export class ContactInterfaceError extends Error {
+    readonly code: ContactErrorCode;
+
+    constructor(code: ContactErrorCode, message: string) {
+        super(message);
+        this.name = "ContactInterfaceError";
+        this.code = code;
+    }
+}

--- a/packages/server/src/server/api/interfaces/contactInterface.ts
+++ b/packages/server/src/server/api/interfaces/contactInterface.ts
@@ -6,6 +6,7 @@ import * as base64 from "byte-base64";
 import { deduplicateObjectArray, isEmpty, isNotEmpty } from "@server/helpers/utils";
 import type { FindOptionsWhere } from "typeorm";
 import { ContactsLib } from "../lib/ContactsLib";
+import { CONTACT_ERROR_CODES, ContactInterfaceError } from "./contactErrors";
 
 type GenericContactParams = {
     contactId?: number;
@@ -293,7 +294,8 @@ export class ContactInterface {
             isEmpty(lastName) &&
             isEmpty(displayName)
         ) {
-            throw new Error(
+            throw new ContactInterfaceError(
+                CONTACT_ERROR_CODES.MISSING_UPDATE_IDENTITY,
                 "To update an existing contact, you must provide one of the following: " +
                     "id, externalId, firstName, lastName, displayName"
             );
@@ -318,13 +320,17 @@ export class ContactInterface {
         }
 
         if (updateEntry && existingContacts.length > 1) {
-            throw new Error(
+            throw new ContactInterfaceError(
+                CONTACT_ERROR_CODES.AMBIGUOUS_UPDATE_MATCH,
                 "Failed to update Contact! Criteria returned multiple Contacts. " +
                     "Please add additional criteria, i.e.: firstName, lastName, displayName"
             );
         }
         if (!updateEntry && isNotEmpty(existingContacts)) {
-            throw new Error("Failed to create new Contact! Existing contact with similar info already exists!");
+            throw new ContactInterfaceError(
+                CONTACT_ERROR_CODES.DUPLICATE_CONTACT,
+                "Failed to create new Contact! Existing contact with similar info already exists!"
+            );
         }
 
         contact = isEmpty(existingContacts) ? null : existingContacts[0];

--- a/packages/server/src/server/services/oauthService/contactSyncLogging.ts
+++ b/packages/server/src/server/services/oauthService/contactSyncLogging.ts
@@ -1,0 +1,77 @@
+export type GoogleContactSyncCounts = {
+    total: number;
+    succeeded: number;
+    skipped: number;
+    failed: number;
+};
+
+export type GoogleContactSyncLogContext = {
+    contactIndex: number;
+    hasResourceName: boolean;
+    hasNameRecord: boolean;
+    hasGivenName: boolean;
+    hasFamilyName: boolean;
+    hasDisplayName: boolean;
+    hasPhoneNumbers: boolean;
+    hasEmailAddresses: boolean;
+    hasPhotos: boolean;
+};
+
+type GoogleContactName = {
+    givenName?: unknown;
+    familyName?: unknown;
+    displayName?: unknown;
+};
+
+type GoogleContact = {
+    resourceName?: unknown;
+    names?: GoogleContactName[];
+    phoneNumbers?: unknown[];
+    emailAddresses?: unknown[];
+    photos?: unknown[];
+};
+
+const hasText = (value: unknown): boolean => typeof value === "string" && value.trim().length > 0;
+
+const hasItems = (value: unknown): boolean => Array.isArray(value) && value.length > 0;
+
+export const getGoogleContactSyncLogContext = (
+    contact: GoogleContact,
+    contactIndex: number
+): GoogleContactSyncLogContext => {
+    const name = hasItems(contact?.names) ? contact.names[0] : null;
+
+    return {
+        contactIndex,
+        hasResourceName: hasText(contact?.resourceName),
+        hasNameRecord: !!name,
+        hasGivenName: hasText(name?.givenName),
+        hasFamilyName: hasText(name?.familyName),
+        hasDisplayName: hasText(name?.displayName),
+        hasPhoneNumbers: hasItems(contact?.phoneNumbers),
+        hasEmailAddresses: hasItems(contact?.emailAddresses),
+        hasPhotos: hasItems(contact?.photos)
+    };
+};
+
+export const formatGoogleContactSyncLogContext = (context: GoogleContactSyncLogContext): string =>
+    Object.entries(context)
+        .map(([key, value]) => `${key}=${value}`)
+        .join(", ");
+
+export const formatGoogleContactSyncSummary = (counts: GoogleContactSyncCounts): string =>
+    `${counts.succeeded} succeeded, ${counts.skipped} skipped, ${counts.failed} failed (${counts.total} total)`;
+
+export const getGoogleContactSyncFailureReason = (error: any): string => {
+    const message = typeof error?.message === "string" ? error.message : "";
+
+    if (message.includes("must provide one of")) return "missing-contact-identity";
+    if (message.includes("Criteria returned multiple Contacts")) return "ambiguous-contact-match";
+    if (message.includes("Existing contact with similar info")) return "duplicate-contact";
+
+    const rawCode = error?.code;
+    const code = typeof rawCode === "string" || typeof rawCode === "number" ? String(rawCode) : "";
+    if (/^[a-zA-Z0-9_.-]{1,64}$/.test(code)) return `error-code-${code}`;
+
+    return "unknown-error";
+};

--- a/packages/server/src/server/services/oauthService/contactSyncLogging.ts
+++ b/packages/server/src/server/services/oauthService/contactSyncLogging.ts
@@ -1,3 +1,7 @@
+import { CONTACT_ERROR_CODES, ContactErrorCode } from "@server/api/interfaces/contactErrors";
+
+const KNOWN_CONTACT_ERROR_CODES = new Set<ContactErrorCode>(Object.values(CONTACT_ERROR_CODES));
+
 export type GoogleContactSyncCounts = {
     total: number;
     succeeded: number;
@@ -63,15 +67,7 @@ export const formatGoogleContactSyncSummary = (counts: GoogleContactSyncCounts):
     `${counts.succeeded} succeeded, ${counts.skipped} skipped, ${counts.failed} failed (${counts.total} total)`;
 
 export const getGoogleContactSyncFailureReason = (error: any): string => {
-    const message = typeof error?.message === "string" ? error.message : "";
-
-    if (message.includes("must provide one of")) return "missing-contact-identity";
-    if (message.includes("Criteria returned multiple Contacts")) return "ambiguous-contact-match";
-    if (message.includes("Existing contact with similar info")) return "duplicate-contact";
-
-    const rawCode = error?.code;
-    const code = typeof rawCode === "string" || typeof rawCode === "number" ? String(rawCode) : "";
-    if (/^[a-zA-Z0-9_.-]{1,64}$/.test(code)) return `error-code-${code}`;
+    if (KNOWN_CONTACT_ERROR_CODES.has(error?.code)) return error.code;
 
     return "unknown-error";
 };

--- a/packages/server/src/server/services/oauthService/index.ts
+++ b/packages/server/src/server/services/oauthService/index.ts
@@ -15,6 +15,13 @@ import { FCMService } from "../fcmService";
 import { BrowserWindow, HandlerDetails } from "electron";
 import { Loggable } from "@server/lib/logging/Loggable";
 import { ContactInterface } from "@server/api/interfaces/contactInterface";
+import {
+    formatGoogleContactSyncLogContext,
+    formatGoogleContactSyncSummary,
+    getGoogleContactSyncFailureReason,
+    getGoogleContactSyncLogContext,
+    GoogleContactSyncCounts
+} from "./contactSyncLogging";
 
 /**
  * This service class hhandles the initial oauth workflows
@@ -213,33 +220,55 @@ export class OauthService extends Loggable {
             const contacts = await this.fetchContacts();
 
             this.log.info(`Saving ${contacts.length} contact(s) to the server...`);
-            let errored = false;
-            for (const contact of contacts) {
-                if (isEmpty(contact.names)) continue;
+            const counts: GoogleContactSyncCounts = {
+                total: contacts.length,
+                succeeded: 0,
+                skipped: 0,
+                failed: 0
+            };
+
+            for (const [index, contact] of contacts.entries()) {
+                if (isEmpty(contact?.names)) {
+                    counts.skipped += 1;
+                    continue;
+                }
 
                 try {
                     const avatar = await this.loadContactAvatar(contact);
+                    const name = contact.names[0] ?? {};
 
                     await ContactInterface.createOrUpdateContact({
-                        firstName: contact.names[0].givenName,
-                        lastName: contact.names[0].familyName,
-                        displayName: contact.names[0].displayName,
+                        firstName: name.givenName,
+                        lastName: name.familyName,
+                        displayName: name.displayName,
                         phoneNumbers: (contact.phoneNumbers ?? []).map((p: any) => p.canonicalForm ?? p.value),
                         emails: (contact.emailAddresses ?? []).map((e: any) => e.value),
                         updateEntry: true,
                         avatar
                     });
+
+                    counts.succeeded += 1;
                 } catch (ex: any) {
-                    errored = true;
-                    this.log.debug(`Failed to save contact: ${ex?.message}`);
+                    counts.failed += 1;
+
+                    const context = getGoogleContactSyncLogContext(contact, index + 1);
+                    const failureReason = getGoogleContactSyncFailureReason(ex);
+                    this.log.debug(
+                        `Failed to save Google contact (${formatGoogleContactSyncLogContext(context)}, ` +
+                            `failureReason=${failureReason}).`
+                    );
                 }
             }
 
-            if (errored) {
-                this.log.warn(`Some contacts failed to save. Please check the server logs for more information.`);
+            const summary = formatGoogleContactSyncSummary(counts);
+            if (counts.failed > 0) {
+                this.log.warn(
+                    `Finished saving Google contacts with failures: ${summary}. ` +
+                        `Please check the debug logs for privacy-safe failure details.`
+                );
+            } else {
+                this.log.info(`Finished saving Google contacts: ${summary}.`);
             }
-
-            this.log.info(`Finished saving contacts to the server!`);
 
             try {
                 this.log.info(`Revoking OAuth token, to prevent further use...`);

--- a/packages/server/test/contactSyncLogging.test.cjs
+++ b/packages/server/test/contactSyncLogging.test.cjs
@@ -1,0 +1,119 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const babel = require("@babel/core");
+
+const modulePath = path.join(__dirname, "../src/server/services/oauthService/contactSyncLogging.ts");
+const transformed = babel.transformFileSync(modulePath, {
+    presets: [
+        [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
+        require.resolve("@babel/preset-typescript")
+    ]
+});
+const loadedModule = { exports: {} };
+const loadModule = new Function("module", "exports", "require", transformed.code);
+loadModule(loadedModule, loadedModule.exports, require);
+
+const {
+    formatGoogleContactSyncLogContext,
+    formatGoogleContactSyncSummary,
+    getGoogleContactSyncFailureReason,
+    getGoogleContactSyncLogContext
+} = loadedModule.exports;
+
+test("contact sync context exposes field presence without provider values", () => {
+    const contact = {
+        resourceName: "people/private-resource-id",
+        names: [
+            {
+                givenName: "PrivateGivenName",
+                familyName: "PrivateFamilyName",
+                displayName: "PrivateDisplayName"
+            }
+        ],
+        phoneNumbers: [{ value: "+15555550123" }],
+        emailAddresses: [{ value: "private@example.com" }],
+        photos: [{ url: "https://example.com/private-avatar" }]
+    };
+
+    const context = getGoogleContactSyncLogContext(contact, 3);
+    assert.deepEqual(context, {
+        contactIndex: 3,
+        hasResourceName: true,
+        hasNameRecord: true,
+        hasGivenName: true,
+        hasFamilyName: true,
+        hasDisplayName: true,
+        hasPhoneNumbers: true,
+        hasEmailAddresses: true,
+        hasPhotos: true
+    });
+
+    const formatted = formatGoogleContactSyncLogContext(context);
+    for (const privateValue of [
+        contact.resourceName,
+        contact.names[0].givenName,
+        contact.names[0].familyName,
+        contact.names[0].displayName,
+        contact.phoneNumbers[0].value,
+        contact.emailAddresses[0].value,
+        contact.photos[0].url
+    ]) {
+        assert.equal(formatted.includes(privateValue), false);
+    }
+});
+
+test("contact sync context treats empty provider fields as absent", () => {
+    assert.deepEqual(
+        getGoogleContactSyncLogContext(
+            {
+                resourceName: " ",
+                names: [{ givenName: "", familyName: null, displayName: undefined }],
+                phoneNumbers: [],
+                emailAddresses: [],
+                photos: []
+            },
+            1
+        ),
+        {
+            contactIndex: 1,
+            hasResourceName: false,
+            hasNameRecord: true,
+            hasGivenName: false,
+            hasFamilyName: false,
+            hasDisplayName: false,
+            hasPhoneNumbers: false,
+            hasEmailAddresses: false,
+            hasPhotos: false
+        }
+    );
+});
+
+test("contact sync summary reports every result category", () => {
+    assert.equal(
+        formatGoogleContactSyncSummary({
+            total: 7,
+            succeeded: 4,
+            skipped: 2,
+            failed: 1
+        }),
+        "4 succeeded, 2 skipped, 1 failed (7 total)"
+    );
+});
+
+test("failure reasons do not echo arbitrary exception text", () => {
+    assert.equal(
+        getGoogleContactSyncFailureReason({
+            message: "To update an existing contact, you must provide one of the following: firstName"
+        }),
+        "missing-contact-identity"
+    );
+
+    const privateMessage = "Database failed for private@example.com and +15555550123";
+    const reason = getGoogleContactSyncFailureReason({ message: privateMessage });
+    assert.equal(reason, "unknown-error");
+    assert.equal(reason.includes(privateMessage), false);
+
+    assert.equal(getGoogleContactSyncFailureReason({ code: "SQLITE_CONSTRAINT" }), "error-code-SQLITE_CONSTRAINT");
+    assert.equal(getGoogleContactSyncFailureReason({ code: "unsafe code with spaces" }), "unknown-error");
+});

--- a/packages/server/test/contactSyncLogging.test.cjs
+++ b/packages/server/test/contactSyncLogging.test.cjs
@@ -3,16 +3,25 @@ const path = require("node:path");
 const test = require("node:test");
 const babel = require("@babel/core");
 
+const transformModule = modulePath =>
+    babel.transformFileSync(modulePath, {
+        presets: [
+            [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
+            require.resolve("@babel/preset-typescript")
+        ]
+    }).code;
+
+const contactErrorsPath = path.join(__dirname, "../src/server/api/interfaces/contactErrors.ts");
+const contactErrorsModule = { exports: {} };
+const loadContactErrors = new Function("module", "exports", "require", transformModule(contactErrorsPath));
+loadContactErrors(contactErrorsModule, contactErrorsModule.exports, require);
+
 const modulePath = path.join(__dirname, "../src/server/services/oauthService/contactSyncLogging.ts");
-const transformed = babel.transformFileSync(modulePath, {
-    presets: [
-        [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
-        require.resolve("@babel/preset-typescript")
-    ]
-});
 const loadedModule = { exports: {} };
-const loadModule = new Function("module", "exports", "require", transformed.code);
-loadModule(loadedModule, loadedModule.exports, require);
+const loadModule = new Function("module", "exports", "require", transformModule(modulePath));
+const loadDependency = moduleId =>
+    moduleId === "@server/api/interfaces/contactErrors" ? contactErrorsModule.exports : require(moduleId);
+loadModule(loadedModule, loadedModule.exports, loadDependency);
 
 const {
     formatGoogleContactSyncLogContext,
@@ -20,6 +29,7 @@ const {
     getGoogleContactSyncFailureReason,
     getGoogleContactSyncLogContext
 } = loadedModule.exports;
+const { CONTACT_ERROR_CODES } = contactErrorsModule.exports;
 
 test("contact sync context exposes field presence without provider values", () => {
     const contact = {
@@ -101,19 +111,16 @@ test("contact sync summary reports every result category", () => {
     );
 });
 
-test("failure reasons do not echo arbitrary exception text", () => {
-    assert.equal(
-        getGoogleContactSyncFailureReason({
-            message: "To update an existing contact, you must provide one of the following: firstName"
-        }),
-        "missing-contact-identity"
-    );
+test("failure reasons consume only stable ContactInterface codes", () => {
+    for (const code of Object.values(CONTACT_ERROR_CODES)) {
+        assert.equal(getGoogleContactSyncFailureReason({ code }), code);
+    }
 
     const privateMessage = "Database failed for private@example.com and +15555550123";
     const reason = getGoogleContactSyncFailureReason({ message: privateMessage });
     assert.equal(reason, "unknown-error");
     assert.equal(reason.includes(privateMessage), false);
 
-    assert.equal(getGoogleContactSyncFailureReason({ code: "SQLITE_CONSTRAINT" }), "error-code-SQLITE_CONSTRAINT");
+    assert.equal(getGoogleContactSyncFailureReason({ code: "SQLITE_CONSTRAINT" }), "unknown-error");
     assert.equal(getGoogleContactSyncFailureReason({ code: "unsafe code with spaces" }), "unknown-error");
 });


### PR DESCRIPTION
## Summary

- report succeeded, skipped, failed, and total counts after Google contact sync
- add per-contact debug context using only the one-based batch index and field-presence booleans
- represent known contact failures with typed `ContactInterfaceError` codes
- accept only the fixed `CONTACT_ERROR_CODES` allow-list in logs; collapse all arbitrary messages and unrecognized codes to `unknown-error`
- add focused privacy and result-formatting tests

## Why

Issue #677 asks for enough detail to understand partial Google contact imports. The previous implementation tracked only whether any contact failed and logged the raw exception message. That made the final warning difficult to act on and could expose contact or provider data.

## Implementation

The final sync summary distinguishes contacts that were saved, skipped because Google supplied no name record, or failed during avatar loading or persistence. Failure debug context contains only:

- the contact's one-based position in the fetched batch
- booleans describing whether supported fields were present
- a stable failure reason from the typed contact-error allow-list, or `unknown-error`

It does not log names, phone numbers, email addresses, avatar URLs, Google resource identifiers, provider payloads, arbitrary exception messages, or merely string-shaped error codes.

## Validation

Passed on the current head:

- `node --test test/contactSyncLogging.test.cjs` — 4/4 tests
- targeted ESLint
- `git diff --check`

The tests cover aggregate formatting, present and empty field context, every allow-listed contact error, rejection of arbitrary codes, and suppression of provider/contact values and exception text.

No live Google OAuth/contact import was performed, so validation is limited to the focused automated coverage.

Fixes #677
