### PR TITLE
Restore legacy macOS update manifest generation

### DIFF
--- a/packages/server/scripts/electron-builder-config.js
+++ b/packages/server/scripts/electron-builder-config.js
@@ -56,7 +56,7 @@ module.exports = {
     },
     "dmg": {
         "sign": false,
-        "writeUpdateInfo": false
+        "writeUpdateInfo": true
     },
     // "afterSign": "./scripts/notarize.js"
 };


### PR DESCRIPTION
## Summary

- re-enable electron-builder update metadata for macOS DMG releases
- restore generation and publication eligibility of `latest-mac.yml` without changing the current updater implementation

## Root cause

Commit `a72ef646` disabled `dmg.writeUpdateInfo`, so release packaging stopped producing the legacy manifest that older BlueBubbles servers still check.

## User impact

Older installations can discover that a newer release exists. Their legacy updater may still be unable to complete the upgrade, but the manifest restores the update notification path requested in the issue.

## Validation

Passed:

- loaded `electron-builder-config.js` under Node 20 and asserted:
  - `dmg.writeUpdateInfo === true`
  - the release target still includes x64 and arm64 DMGs
  - the configured publisher remains the BlueBubbles GitHub draft release
- a non-publishing electron-builder 24.13.3 fixture using this configuration produced both architecture DMGs plus `latest-mac.yml`
- the generated manifest listed both DMGs, and each recorded size and SHA-512 matched its artifact
- inspected the locked electron-builder 24.13.3 path:
  - a DMG with update info queues an update-info task
  - `writeUpdateInfoFiles()` combines both architecture entries
  - the resulting `latest-mac.yml` is dispatched as a publish artifact with the same GitHub publish configuration
- confirmed the repository release workflow calls electron-builder with `--publish always` and `GH_TOKEN`
- `git diff --check`

## Release verification

No GitHub release was created or modified for this PR. Exercising the final upload would require the upstream release credentials and would create or alter the configured BlueBubbles draft release. Because the generated manifest enters electron-builder's existing artifact publisher—the same release mechanism already responsible for the DMGs—that external upload is an operational check for the next maintainer release, not a code-level merge blocker.

After merge, the release maintainer should still confirm that `latest-mac.yml` appears beside both DMGs in the next macOS draft release.

Fixes #817
