### PR TITLE
Prevent duplicate reconciled message events with a keyed cache

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,7 @@
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
+        "test:message-cache": "node --test test/messageCacheRetention.test.cjs",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/src/server/databases/imessage/pollers/MessagePoller.ts
+++ b/packages/server/src/server/databases/imessage/pollers/MessagePoller.ts
@@ -2,7 +2,7 @@ import { IMessagePollResult, IMessagePollType, IMessagePoller } from ".";
 import { Message } from "../entity/Message";
 import { isEmpty } from "@server/helpers/utils";
 import { Server } from "@server";
-
+import { MESSAGE_FAST_LOOKBACK_MS, MESSAGE_RECONCILE_INTERVAL_MS, MESSAGE_RECONCILE_LOOKBACK_MS } from "./constants";
 
 export class MessagePoller extends IMessagePoller {
     tag = "MessagePoller";
@@ -13,14 +13,14 @@ export class MessagePoller extends IMessagePoller {
 
     // Apple only allows edits within ~15 minutes and unsends within ~2 minutes of sending,
     // so a much smaller lookback than a full week is enough to catch those on every tick.
-    static readonly FAST_LOOKBACK_MS = 1000 * 60 * 30;
+    static readonly FAST_LOOKBACK_MS = MESSAGE_FAST_LOOKBACK_MS;
 
     // Periodically we still widen the lookback to a full week so we don't permanently miss
     // things that can legitimately change well outside the fast window (e.g. a read receipt
     // or notification flag on an older message).
-    static readonly RECONCILE_LOOKBACK_MS = 1000 * 60 * 60 * 24 * 7;
+    static readonly RECONCILE_LOOKBACK_MS = MESSAGE_RECONCILE_LOOKBACK_MS;
 
-    static readonly RECONCILE_INTERVAL_MS = 1000 * 60 * 5;
+    static readonly RECONCILE_INTERVAL_MS = MESSAGE_RECONCILE_INTERVAL_MS;
 
     lastReconcileAt = 0;
 
@@ -59,7 +59,7 @@ export class MessagePoller extends IMessagePoller {
             // Date read only matters if it's from you and it's not a group chat
             (e.isFromMe && !e.chats[0].isGroup && (e.dateRead?.getTime() ?? 0)) >= afterTime ||
             // Date edited can be from anyone (should include edits & unsends)
-            (e.dateEdited?.getTime() ?? 0) >= afterTime || 
+            (e.dateEdited?.getTime() ?? 0) >= afterTime ||
             // Date retracted can be from anyone, but Apple doesn't even use this field.
             // We still want to be thorough and check it.
             // isEmpty is what's actually used by Apple to determine if it's retracted.
@@ -143,10 +143,10 @@ export class MessagePoller extends IMessagePoller {
             const identifier = `group-change-${entry.ROWID}`;
 
             // Skip over any that we've finished
-            if (this.cache.events.find(identifier)) continue;
+            if (this.cache.messageEvents.find(identifier)) continue;
 
             // Add to cache
-            this.cache.events.add(identifier);
+            this.cache.messageEvents.add(identifier);
 
             // Send the built message object
             if (entry.itemType === 1 && entry.groupActionType === 0) {

--- a/packages/server/src/server/databases/imessage/pollers/constants.ts
+++ b/packages/server/src/server/databases/imessage/pollers/constants.ts
@@ -1,0 +1,10 @@
+export const MESSAGE_FAST_LOOKBACK_MS = 1000 * 60 * 30;
+
+export const MESSAGE_RECONCILE_LOOKBACK_MS = 1000 * 60 * 60 * 24 * 7;
+
+export const MESSAGE_RECONCILE_INTERVAL_MS = 1000 * 60 * 5;
+
+// Keep GUIDs through one final reconciliation after they age out of the query window.
+export const MESSAGE_DEDUP_CACHE_RETENTION_MS = MESSAGE_RECONCILE_LOOKBACK_MS + MESSAGE_RECONCILE_INTERVAL_MS;
+
+export const CHAT_DEDUP_CACHE_RETENTION_MS = 1000 * 60 * 60;

--- a/packages/server/src/server/databases/imessage/pollers/index.ts
+++ b/packages/server/src/server/databases/imessage/pollers/index.ts
@@ -4,6 +4,7 @@ import { Message } from "../entity/Message";
 import { CHAT_READ_STATUS_CHANGED } from "@server/events";
 import { Chat } from "../entity/Chat";
 import { Loggable } from "@server/lib/logging/Loggable";
+import { CHAT_DEDUP_CACHE_RETENTION_MS, MESSAGE_DEDUP_CACHE_RETENTION_MS } from "./constants";
 
 export type IMessagePollResult = {
     eventType: string;
@@ -37,27 +38,26 @@ export class IMessageCache {
 
     chatStates: Record<string, ChatState> = {};
 
-    events: EventCache;
+    messageEvents: EventCache;
+
+    chatEvents: EventCache;
 
     constructor() {
-        this.events = new EventCache();
+        this.messageEvents = new EventCache();
+        this.chatEvents = new EventCache();
     }
 
     trimCaches() {
         this.trimMessageStates();
         this.trimChatStates();
-        this.trimEventCache();
-    }
-
-    private trimEventCache() {
-        this.events.trim(1000 * 60 * 60);
+        this.messageEvents.trim(MESSAGE_DEDUP_CACHE_RETENTION_MS);
+        this.chatEvents.trim(CHAT_DEDUP_CACHE_RETENTION_MS);
     }
 
     private trimMessageStates() {
         const now = new Date().getTime();
         for (const guid in this.messageStates) {
-            // Clear entries older than 1 hour
-            if (this.messageStates[guid].cacheTime < now - 1000 * 60 * 60) {
+            if (this.messageStates[guid].cacheTime < now - MESSAGE_DEDUP_CACHE_RETENTION_MS) {
                 delete this.messageStates[guid];
             }
         }
@@ -67,11 +67,10 @@ export class IMessageCache {
         const now = new Date().getTime();
         for (const guid in this.chatStates) {
             // Clear entries older than 1 hour
-            if (this.chatStates[guid].cacheTime < now - 1000 * 60 * 60) {
+            if (this.chatStates[guid].cacheTime < now - CHAT_DEDUP_CACHE_RETENTION_MS) {
                 delete this.chatStates[guid];
             }
         }
-    
     }
 }
 
@@ -96,7 +95,7 @@ export abstract class IMessagePoller extends Loggable {
     getMessageEvent(message: Message): string | null {
         // If the GUID doesn't exist, it's a new message
         const guid = message.guid;
-        if (!this.cache.events.find(guid)) return "new-entry";
+        if (!this.cache.messageEvents.find(guid)) return "new-entry";
 
         // If the GUID exists, check the date created.
         // If it doesn't exist, a race condition occurred and we should ignore it (return null)
@@ -135,7 +134,7 @@ export abstract class IMessagePoller extends Loggable {
         if (!event) return null;
 
         if (event === "new-entry") {
-            this.cache.events.add(message.guid);
+            this.cache.messageEvents.add(message.guid);
         }
 
         this.cache.messageStates[message.guid] = {
@@ -157,7 +156,7 @@ export abstract class IMessagePoller extends Loggable {
         // If the GUID doesn't exist, it's a new chat
         const guid = chat.guid;
 
-        if (!this.cache.events.find(guid)) return defaultEvent;
+        if (!this.cache.chatEvents.find(guid)) return defaultEvent;
 
         // If the GUID exists, check the date created.
         // If it doesn't exist, a race condition occurred and we should ignore it (return null)
@@ -177,7 +176,7 @@ export abstract class IMessagePoller extends Loggable {
         if (!event) return null;
 
         if (event === defaultEvent) {
-            this.cache.events.add(chat.guid);
+            this.cache.chatEvents.add(chat.guid);
         }
 
         this.cache.chatStates[chat.guid] = {

--- a/packages/server/src/server/databases/imessage/pollers/index.ts
+++ b/packages/server/src/server/databases/imessage/pollers/index.ts
@@ -1,4 +1,4 @@
-import { EventCache } from "@server/eventCache";
+import { EventCache, KeyedEventCache } from "@server/eventCache";
 import { MessageRepository } from "..";
 import { Message } from "../entity/Message";
 import { CHAT_READ_STATUS_CHANGED } from "@server/events";
@@ -38,12 +38,12 @@ export class IMessageCache {
 
     chatStates: Record<string, ChatState> = {};
 
-    messageEvents: EventCache;
+    messageEvents: KeyedEventCache;
 
     chatEvents: EventCache;
 
     constructor() {
-        this.messageEvents = new EventCache();
+        this.messageEvents = new KeyedEventCache();
         this.chatEvents = new EventCache();
     }
 

--- a/packages/server/src/server/eventCache/index.ts
+++ b/packages/server/src/server/eventCache/index.ts
@@ -43,3 +43,42 @@ export class EventCache {
         this.items = this.items.filter(i => item !== i.item);
     }
 }
+
+/**
+ * A keyed cache for high-volume event streams where linear lookup is too costly.
+ */
+export class KeyedEventCache {
+    items: Map<string, number> = new Map();
+
+    purge() {
+        if (this.items.size === 0) return;
+        console.info(`Purging ${this.size()} items from cache...`);
+        this.items.clear();
+    }
+
+    trim(msOld: number) {
+        const now = new Date().getTime();
+        for (const [item, date] of this.items) {
+            if (now - date >= msOld) this.items.delete(item);
+        }
+    }
+
+    size() {
+        return this.items.size;
+    }
+
+    add(item: string): boolean {
+        if (isEmpty(item) || this.items.has(item)) return false;
+        this.items.set(item, new Date().getTime());
+        return true;
+    }
+
+    find(item: string): string | null {
+        return this.items.has(item) ? item : null;
+    }
+
+    remove(item: string) {
+        if (!item) return;
+        this.items.delete(item);
+    }
+}

--- a/packages/server/test/messageCacheRetention.test.cjs
+++ b/packages/server/test/messageCacheRetention.test.cjs
@@ -1,0 +1,106 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const babel = require("@babel/core");
+
+const loadTypeScriptModule = (modulePath, overrides = {}) => {
+    const transformed = babel.transformFileSync(modulePath, {
+        presets: [
+            [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
+            require.resolve("@babel/preset-typescript")
+        ]
+    });
+    const loadedModule = { exports: {} };
+    const loadModule = new Function("module", "exports", "require", transformed.code);
+    const customRequire = request => overrides[request] ?? require(request);
+    loadModule(loadedModule, loadedModule.exports, customRequire);
+    return loadedModule.exports;
+};
+
+const constantsPath = path.join(__dirname, "../src/server/databases/imessage/pollers/constants.ts");
+const constants = loadTypeScriptModule(constantsPath);
+
+const eventCachePath = path.join(__dirname, "../src/server/eventCache/index.ts");
+const { EventCache } = loadTypeScriptModule(eventCachePath, {
+    "@server/helpers/utils": {
+        isEmpty: value => value === null || value === undefined || value.length === 0
+    }
+});
+
+const pollerPath = path.join(__dirname, "../src/server/databases/imessage/pollers/index.ts");
+const { IMessageCache, IMessagePoller } = loadTypeScriptModule(pollerPath, {
+    "@server/eventCache": { EventCache },
+    "@server/events": { CHAT_READ_STATUS_CHANGED: "chat-read-status-changed" },
+    "@server/lib/logging/Loggable": { Loggable: class {} },
+    "./constants": constants
+});
+
+const makeMessage = guid => ({
+    guid,
+    dateCreated: new Date(1_000),
+    isDelivered: false,
+    dateDelivered: null,
+    dateRead: null,
+    dateEdited: null,
+    dateRetracted: null,
+    didNotifyRecipient: true,
+    hasUnsentParts: false
+});
+
+const makeMessageState = cacheTime => ({
+    cacheTime,
+    dateCreated: 1_000,
+    isDelivered: false,
+    dateDelivered: 0,
+    dateRead: 0,
+    dateEdited: 0,
+    dateRetracted: 0,
+    didNotifyRecipient: true,
+    hasUnsentParts: false
+});
+
+test("a reconciled message stays deduplicated for the full lookback", () => {
+    const cache = new IMessageCache();
+    const poller = new IMessagePoller({}, cache);
+    const guid = "reconciled-message";
+    const reconciledAt = Date.now() - constants.MESSAGE_RECONCILE_LOOKBACK_MS;
+
+    cache.messageEvents.items.push({ date: reconciledAt, item: guid });
+    cache.messageStates[guid] = makeMessageState(reconciledAt);
+
+    cache.trimCaches();
+
+    assert.equal(cache.messageEvents.find(guid), guid);
+    assert.equal(poller.processMessageEvent(makeMessage(guid)), null);
+});
+
+test("expired message entries are still pruned", () => {
+    const cache = new IMessageCache();
+    const guid = "expired-message";
+    const expiredAt = Date.now() - constants.MESSAGE_DEDUP_CACHE_RETENTION_MS - 1;
+
+    cache.messageEvents.items.push({ date: expiredAt, item: guid });
+    cache.messageStates[guid] = makeMessageState(expiredAt);
+
+    cache.trimCaches();
+
+    assert.equal(cache.messageEvents.find(guid), null);
+    assert.equal(cache.messageStates[guid], undefined);
+});
+
+test("chat deduplication keeps its shorter retention", () => {
+    const cache = new IMessageCache();
+    const guid = "expired-chat";
+    const expiredAt = Date.now() - constants.CHAT_DEDUP_CACHE_RETENTION_MS - 1;
+
+    cache.chatEvents.items.push({ date: expiredAt, item: guid });
+    cache.chatStates[guid] = {
+        cacheTime: expiredAt,
+        lastReadMessageTimestamp: 1_000
+    };
+
+    cache.trimCaches();
+
+    assert.equal(cache.chatEvents.find(guid), null);
+    assert.equal(cache.chatStates[guid], undefined);
+});

--- a/packages/server/test/messageCacheRetention.test.cjs
+++ b/packages/server/test/messageCacheRetention.test.cjs
@@ -21,7 +21,7 @@ const constantsPath = path.join(__dirname, "../src/server/databases/imessage/pol
 const constants = loadTypeScriptModule(constantsPath);
 
 const eventCachePath = path.join(__dirname, "../src/server/eventCache/index.ts");
-const { EventCache } = loadTypeScriptModule(eventCachePath, {
+const { EventCache, KeyedEventCache } = loadTypeScriptModule(eventCachePath, {
     "@server/helpers/utils": {
         isEmpty: value => value === null || value === undefined || value.length === 0
     }
@@ -29,7 +29,7 @@ const { EventCache } = loadTypeScriptModule(eventCachePath, {
 
 const pollerPath = path.join(__dirname, "../src/server/databases/imessage/pollers/index.ts");
 const { IMessageCache, IMessagePoller } = loadTypeScriptModule(pollerPath, {
-    "@server/eventCache": { EventCache },
+    "@server/eventCache": { EventCache, KeyedEventCache },
     "@server/events": { CHAT_READ_STATUS_CHANGED: "chat-read-status-changed" },
     "@server/lib/logging/Loggable": { Loggable: class {} },
     "./constants": constants
@@ -65,7 +65,7 @@ test("a reconciled message stays deduplicated for the full lookback", () => {
     const guid = "reconciled-message";
     const reconciledAt = Date.now() - constants.MESSAGE_RECONCILE_LOOKBACK_MS;
 
-    cache.messageEvents.items.push({ date: reconciledAt, item: guid });
+    cache.messageEvents.items.set(guid, reconciledAt);
     cache.messageStates[guid] = makeMessageState(reconciledAt);
 
     cache.trimCaches();
@@ -79,7 +79,7 @@ test("expired message entries are still pruned", () => {
     const guid = "expired-message";
     const expiredAt = Date.now() - constants.MESSAGE_DEDUP_CACHE_RETENTION_MS - 1;
 
-    cache.messageEvents.items.push({ date: expiredAt, item: guid });
+    cache.messageEvents.items.set(guid, expiredAt);
     cache.messageStates[guid] = makeMessageState(expiredAt);
 
     cache.trimCaches();
@@ -103,4 +103,15 @@ test("chat deduplication keeps its shorter retention", () => {
 
     assert.equal(cache.chatEvents.find(guid), null);
     assert.equal(cache.chatStates[guid], undefined);
+});
+
+test("message event cache uses keyed lookup without changing chat cache storage", () => {
+    const cache = new IMessageCache();
+
+    assert.equal(cache.messageEvents.items instanceof Map, true);
+    assert.equal(Array.isArray(cache.chatEvents.items), true);
+    assert.equal(cache.messageEvents.add("message-guid"), true);
+    assert.equal(cache.messageEvents.add("message-guid"), false);
+    assert.equal(cache.messageEvents.find("message-guid"), "message-guid");
+    assert.equal(cache.messageEvents.size(), 1);
 });


### PR DESCRIPTION
## Summary

- retain message GUIDs and message state for the seven-day reconciliation window plus one reconciliation interval
- use a keyed, `Map`-backed cache for high-volume message-event deduplication
- keep chat event/state retention at one hour and preserve the existing array-backed chat cache
- centralize the message poller's reconciliation and retention constants
- add focused regression coverage for retention, pruning, and cache separation

## Root cause

The message poller periodically widens its query to seven days, but message event and state entries were pruned after one hour. A previously emitted row could therefore lose its GUID and state, then be classified as a new entry when the reconciliation lookback revisited it.

Simply extending the old array-backed event cache would also make high-volume message lookup increasingly expensive. The final implementation separates the two workloads:

- message events use `KeyedEventCache`, backed by `Map` for keyed add/find/remove operations
- chat events continue to use the existing `EventCache` array and one-hour retention
- message event and state entries remain for seven days plus five minutes, covering one final reconciliation after they age out of the query window

## Impact

Long-running servers no longer re-emit unchanged reconciled rows as `new-entry` events after the former one-hour deduplication window. Message lookup no longer performs a linear scan of the retained event set, while chat read-state deduplication keeps its existing storage and retention behavior.

## Validation

Passed on the current head:

- `node --test test/messageCacheRetention.test.cjs` — 4/4 tests
- targeted ESLint
- targeted Prettier check
- `git diff --check`

The tests cover full-lookback deduplication, expiry pruning, one-hour chat retention, `Map`-backed message storage, unchanged array-backed chat storage, and duplicate-key behavior.

`tsc -p packages/server/tsconfig.json --noEmit` still reaches the existing unrelated `ScheduledService.ts:39` `NodeJS.Timer`/`clearInterval` type error.

Fixes #765
