### PR TITLE
Attempt forced restoration for locally missing attachments

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,6 +12,7 @@
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
+        "test:attachment-download": "node --test test/attachmentDownload.test.cjs",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,9 +12,9 @@
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
-        "test:attachment-download": "node --test test/attachmentDownload.test.cjs",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
+        "test:attachment-download": "node --test test/attachmentDownload.test.cjs",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",
         "postinstall": "electron-rebuild install-app-deps && npm run rebuild"
     },

--- a/packages/server/src/server/api/http/api/v1/routers/attachmentRouter.ts
+++ b/packages/server/src/server/api/http/api/v1/routers/attachmentRouter.ts
@@ -34,22 +34,23 @@ export class AttachmentRouter {
         const forceDownload = isTruthyBool((force as string) ?? "true");
 
         // Fetch the info for the attachment by GUID
-        const attachment = await Server().iMessageRepo.getAttachment(guid);
-        if (!attachment) {
-            const papiEnabled = Server().repo.getConfig("enable_private_api") as boolean;
-            if (!forceDownload || !papiEnabled) {
-                throw new NotFound({ error: "Attachment does not exist!" });
-            }
+        let attachment = await Server().iMessageRepo.getAttachment(guid);
+        if (!attachment) throw new NotFound({ error: "Attachment does not exist!" });
 
-            // Try to force download the attachment
-            try {
-                await AttachmentInterface.forceDownload(attachment);
-            } catch (ex) {
-                Server().log(`Failed for force download attachment (GUID: ${attachment.guid}): ${String(ex)}`);
+        let aPath = FileSystem.getRealPath(attachment.filePath);
+        if (!fs.existsSync(aPath) && forceDownload) {
+            const papiEnabled = Server().repo.getConfig("enable_private_api") as boolean;
+            if (papiEnabled) {
+                // Try to restore an attachment that exists in the database but has been purged from disk
+                try {
+                    attachment = await AttachmentInterface.forceDownload(attachment);
+                    aPath = FileSystem.getRealPath(attachment.filePath);
+                } catch (ex) {
+                    Server().log(`Failed to force download attachment (GUID: ${attachment.guid}): ${String(ex)}`);
+                }
             }
         }
 
-        let aPath = FileSystem.getRealPath(attachment.filePath);
         let mimeType = attachment.getMimeType();
         if (!fs.existsSync(aPath)) throw new ServerError({ error: "Attachment does not exist in disk!" });
 

--- a/packages/server/test/attachmentDownload.test.cjs
+++ b/packages/server/test/attachmentDownload.test.cjs
@@ -1,0 +1,190 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const babel = require("@babel/core");
+
+const loadTypeScriptModule = (modulePath, overrides = {}) => {
+    const transformed = babel.transformFileSync(modulePath, {
+        presets: [
+            [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
+            require.resolve("@babel/preset-typescript")
+        ]
+    });
+    const loadedModule = { exports: {} };
+    const loadModule = new Function("module", "exports", "require", transformed.code);
+    const customRequire = request => overrides[request] ?? require(request);
+    loadModule(loadedModule, loadedModule.exports, customRequire);
+    return loadedModule.exports;
+};
+
+class TestHttpError extends Error {
+    constructor(response) {
+        super(response?.error);
+        this.response = response;
+    }
+}
+
+class NotFound extends TestHttpError {
+    status = 404;
+}
+
+class ServerError extends TestHttpError {
+    status = 500;
+}
+
+class BadRequest extends TestHttpError {
+    status = 400;
+}
+
+const attachmentRouterPath = path.join(__dirname, "../src/server/api/http/api/v1/routers/attachmentRouter.ts");
+
+const makeAttachment = ({ guid = "attachment-guid", filePath, mimeType }) => ({
+    guid,
+    filePath,
+    transferName: "attachment",
+    originalGuid: null,
+    getMimeType: () => mimeType
+});
+
+const loadAttachmentRouter = ({ attachment, privateApiEnabled = true, existingPaths = [], forceResult }) => {
+    const calls = {
+        forceDownload: [],
+        config: [],
+        fileStreams: [],
+        logs: []
+    };
+    const server = {
+        iMessageRepo: {
+            getAttachment: async () => attachment
+        },
+        repo: {
+            getConfig: key => {
+                calls.config.push(key);
+                return privateApiEnabled;
+            }
+        },
+        log: (...args) => calls.logs.push(args)
+    };
+
+    class FileStream {
+        constructor(ctx, filePath, mimeType) {
+            calls.fileStreams.push({ ctx, filePath, mimeType });
+        }
+
+        send() {
+            return "sent";
+        }
+    }
+
+    const { AttachmentRouter } = loadTypeScriptModule(attachmentRouterPath, {
+        electron: { nativeImage: {} },
+        fs: { __esModule: true, default: { existsSync: filePath => existingPaths.includes(filePath) } },
+        "@server": { Server: () => server },
+        "@server/fileSystem": {
+            FileSystem: {
+                getRealPath: filePath => filePath
+            }
+        },
+        "@server/databases/imessage/helpers/utils": {
+            convertAudio: async () => null,
+            convertImage: async () => null
+        },
+        "@server/helpers/utils": {
+            isEmpty: value => value === null || value === undefined || value.length === 0,
+            isTruthyBool: value => value === true || value === "true"
+        },
+        "@server/api/interfaces/attachmentInterface": {
+            AttachmentInterface: {
+                forceDownload: async value => {
+                    calls.forceDownload.push(value);
+                    return forceResult;
+                }
+            }
+        },
+        "../responses/success": {
+            FileStream,
+            Success: class {}
+        },
+        "../responses/errors": {
+            BadRequest,
+            NotFound,
+            ServerError
+        },
+        "@server/api/serializers/AttachmentSerializer": {
+            AttachmentSerializer: {}
+        }
+    });
+
+    return { AttachmentRouter, calls };
+};
+
+const makeContext = (query = {}) => ({
+    params: { guid: "attachment-guid" },
+    request: { query }
+});
+
+test("restores a missing local file and streams the refreshed attachment", async () => {
+    const original = makeAttachment({ filePath: "/attachments/missing.jpg", mimeType: "image/jpeg" });
+    const refreshed = makeAttachment({ filePath: "/attachments/restored.png", mimeType: "image/png" });
+    const { AttachmentRouter, calls } = loadAttachmentRouter({
+        attachment: original,
+        existingPaths: [refreshed.filePath],
+        forceResult: refreshed
+    });
+    const ctx = makeContext({ original: "true" });
+
+    assert.equal(await AttachmentRouter.download(ctx), "sent");
+    assert.deepEqual(calls.forceDownload, [original]);
+    assert.deepEqual(calls.fileStreams, [{ ctx, filePath: refreshed.filePath, mimeType: "image/png" }]);
+});
+
+test("returns not found for an absent database row without trying to force download", async () => {
+    const { AttachmentRouter, calls } = loadAttachmentRouter({ attachment: null });
+
+    await assert.rejects(AttachmentRouter.download(makeContext()), error => {
+        assert.equal(error.status, 404);
+        assert.equal(error.response.error, "Attachment does not exist!");
+        return true;
+    });
+    assert.equal(calls.forceDownload.length, 0);
+    assert.equal(calls.config.length, 0);
+});
+
+test("does not force download when force is false", async () => {
+    const attachment = makeAttachment({ filePath: "/attachments/missing.jpg", mimeType: "image/jpeg" });
+    const { AttachmentRouter, calls } = loadAttachmentRouter({ attachment, forceResult: attachment });
+
+    await assert.rejects(AttachmentRouter.download(makeContext({ force: "false" })), error => error.status === 500);
+    assert.equal(calls.forceDownload.length, 0);
+    assert.equal(calls.config.length, 0);
+});
+
+test("does not force download when the Private API is disabled", async () => {
+    const attachment = makeAttachment({ filePath: "/attachments/missing.jpg", mimeType: "image/jpeg" });
+    const { AttachmentRouter, calls } = loadAttachmentRouter({
+        attachment,
+        privateApiEnabled: false,
+        forceResult: attachment
+    });
+
+    await assert.rejects(AttachmentRouter.download(makeContext()), error => error.status === 500);
+    assert.equal(calls.forceDownload.length, 0);
+    assert.deepEqual(calls.config, ["enable_private_api"]);
+});
+
+test("returns a server error when the file is still missing after a force download", async () => {
+    const original = makeAttachment({ filePath: "/attachments/missing.jpg", mimeType: "image/jpeg" });
+    const refreshed = makeAttachment({ filePath: "/attachments/still-missing.jpg", mimeType: "image/jpeg" });
+    const { AttachmentRouter, calls } = loadAttachmentRouter({
+        attachment: original,
+        forceResult: refreshed
+    });
+
+    await assert.rejects(AttachmentRouter.download(makeContext()), error => {
+        assert.equal(error.status, 500);
+        assert.equal(error.response.error, "Attachment does not exist in disk!");
+        return true;
+    });
+    assert.deepEqual(calls.forceDownload, [original]);
+    assert.equal(calls.fileStreams.length, 0);
+});

--- a/packages/server/test/attachmentDownload.test.cjs
+++ b/packages/server/test/attachmentDownload.test.cjs
@@ -46,7 +46,13 @@ const makeAttachment = ({ guid = "attachment-guid", filePath, mimeType }) => ({
     getMimeType: () => mimeType
 });
 
-const loadAttachmentRouter = ({ attachment, privateApiEnabled = true, existingPaths = [], forceResult }) => {
+const loadAttachmentRouter = ({
+    attachment,
+    privateApiEnabled = true,
+    existingPaths = [],
+    forceResult,
+    forceError
+}) => {
     const calls = {
         forceDownload: [],
         config: [],
@@ -97,6 +103,7 @@ const loadAttachmentRouter = ({ attachment, privateApiEnabled = true, existingPa
             AttachmentInterface: {
                 forceDownload: async value => {
                     calls.forceDownload.push(value);
+                    if (forceError) throw forceError;
                     return forceResult;
                 }
             }
@@ -186,5 +193,23 @@ test("returns a server error when the file is still missing after a force downlo
         return true;
     });
     assert.deepEqual(calls.forceDownload, [original]);
+    assert.equal(calls.fileStreams.length, 0);
+});
+
+test("logs a failed force download once and returns a server error without streaming", async () => {
+    const original = makeAttachment({ filePath: "/attachments/missing.jpg", mimeType: "image/jpeg" });
+    const { AttachmentRouter, calls } = loadAttachmentRouter({
+        attachment: original,
+        forceError: new Error("force download failed")
+    });
+
+    await assert.rejects(AttachmentRouter.download(makeContext()), error => {
+        assert.equal(error.status, 500);
+        assert.equal(error.response.error, "Attachment does not exist in disk!");
+        return true;
+    });
+    assert.deepEqual(calls.forceDownload, [original]);
+    assert.equal(calls.logs.length, 1);
+    assert.match(calls.logs[0][0], /GUID: attachment-guid/);
     assert.equal(calls.fileStreams.length, 0);
 });


### PR DESCRIPTION
## Summary

- return `404 Not Found` immediately when no attachment database row exists
- when a row exists but its local file is missing, attempt `forceDownload` only when forcing is allowed and the Private API is enabled
- continue with the refreshed attachment row so a restored path and MIME type can be streamed
- preserve a clean server error when restoration fails or the file remains absent
- add focused mocked tests for success, absent rows, `force=false`, disabled Private API, incomplete restoration, and a rejected `forceDownload`

## Why

The regular attachment download endpoint defaults `force` to `true`, but its recovery branch was attached to the wrong condition. It ran only when the database lookup returned no attachment, even though `AttachmentInterface.forceDownload` requires an existing attachment object. The common case—an intact database row whose local file was purged—therefore never reached the restoration path.

## Behavior

For an eligible missing local file, the endpoint asks the Private API helper to restore the attachment and uses the refreshed row if a file becomes available. Unknown GUIDs remain a deterministic `404`; `force=false` and disabled-Private-API requests do not attempt restoration. A rejected or incomplete restoration logs safely, creates no file stream, and returns the existing clean missing-disk `500`.

## Validation

Validated on current head `58f57f95`:

- `npm run test:attachment-download --workspace @bluebubbles/server` — 6/6 tests passed
- the committed rejection-path test verifies one sanitized GUID-bearing log, no `FileStream`, and the clean `500` fallback
- targeted ESLint, Prettier, and `git diff --check` passed

### Live-validation limitation

**This is not an end-to-end live-restoration pass.** On a SIP-disabled Intel Sequoia host, a naturally purged incoming attachment reached the forced-restoration path and Private API helper, but did not restore within the 10-minute completion wait. The request returned the expected clean fallback `500`; the database row remained incomplete and the local file remained absent. This validates routing and fallback behavior, not successful restoration in that environment.

The broader server type-check still reaches the pre-existing unrelated `ScheduledService.ts:39` `NodeJS.Timer`/`clearInterval` error.

Fixes #749
