### PR TITLE
Retry zrok token setup after stale-environment cleanup

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,7 @@
     "scripts": {
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
+        "test:zrok": "node --test test/zrokManager.test.cjs",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,11 +11,11 @@
     "scripts": {
         "build": "export NODE_ENV=production && webpack --config ./scripts/webpack.main.prod.config.js",
         "start": "export NODE_ENV=development && webpack --config ./scripts/webpack.main.config.js && electron ./dist/main.js",
-        "test:zrok": "node --test test/zrokManager.test.cjs",
         "lint": "eslint --ext=jsx,js,tsx,ts src",
         "dist": "npm run build && electron-builder build --mac --publish never --config ./scripts/electron-builder-config.js",
         "release": "npm run build && electron-builder build --mac --publish always --config ./scripts/electron-builder-config.js",
         "rebuild": "electron-rebuild -f better-sqlite3 node-mac-contacts node-mac-permissions",
+        "test:zrok": "node --test test/zrokManager.test.cjs",
         "postinstall": "electron-rebuild install-app-deps && npm run rebuild"
     },
     "husky": {

--- a/packages/server/src/server/managers/zrokManager/index.ts
+++ b/packages/server/src/server/managers/zrokManager/index.ts
@@ -8,6 +8,8 @@ import { spawn, ChildProcess } from "child_process";
 import path from "path";
 import { ProcessSpawner, ProcessSpawnerError } from "@server/lib/ProcessSpawner";
 
+const ALREADY_ENABLED_ENVIRONMENT_ERROR = "you already have an enabled environment";
+
 export class ZrokManager extends Loggable {
     tag = "ZrokManager";
 
@@ -158,19 +160,33 @@ export class ZrokManager extends Loggable {
 
     static async setToken(token: string): Promise<string> {
         const logger = getLogger("ZrokManager");
+        const enable = () => ProcessSpawner.executeCommand(this.daemonPath, ["enable", token], {}, "ZrokManager");
+        const throwEnableError = (ex: any | ProcessSpawnerError): never => {
+            const output = ex?.output ?? ex?.message ?? String(ex);
+            if (output.includes("enableUnauthorized")) {
+                throw new Error("Invalid Zrok token!");
+            }
 
+            logger.error(`Failed to set Zrok token! Error: ${output}`);
+            throw new Error("Failed to set Zrok token! Please check your server logs for more information.");
+        };
+
+        logger.info(`Enabling Zrok...`);
         try {
-            logger.info(`Enabling Zrok...`);
-            return await ProcessSpawner.executeCommand(this.daemonPath, ["enable", token], {}, "ZrokManager");
+            return await enable();
         } catch (ex: any | ProcessSpawnerError) {
             const output = ex?.output ?? ex?.message ?? String(ex);
-            if (output.includes("you already have an enabled environment")) {
-                return output;
-            } else if (output.includes("enableUnauthorized")) {
-                throw new Error("Invalid Zrok token!");
-            } else {
-                logger.error(`Failed to set Zrok token! Error: ${output}`);
-                throw new Error("Failed to set Zrok token! Please check your server logs for more information.");
+            if (!output.includes(ALREADY_ENABLED_ENVIRONMENT_ERROR)) {
+                return throwEnableError(ex);
+            }
+
+            logger.info("Zrok already has an enabled environment. Disabling it before retrying...");
+            await this.disable();
+
+            try {
+                return await enable();
+            } catch (retryEx: any | ProcessSpawnerError) {
+                return throwEnableError(retryEx);
             }
         }
     }

--- a/packages/server/test/zrokManager.test.cjs
+++ b/packages/server/test/zrokManager.test.cjs
@@ -1,0 +1,141 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+const babel = require("@babel/core");
+
+const loadTypeScriptModule = (modulePath, overrides = {}) => {
+    const transformed = babel.transformFileSync(modulePath, {
+        presets: [
+            [require.resolve("@babel/preset-env"), { targets: { node: "20" }, modules: "commonjs" }],
+            require.resolve("@babel/preset-typescript")
+        ]
+    });
+    const loadedModule = { exports: {} };
+    const loadModule = new Function("module", "exports", "require", transformed.code);
+    const customRequire = request =>
+        Object.prototype.hasOwnProperty.call(overrides, request) ? overrides[request] : require(request);
+    loadModule(loadedModule, loadedModule.exports, customRequire);
+    return loadedModule.exports;
+};
+
+const zrokManagerPath = path.join(__dirname, "../src/server/managers/zrokManager/index.ts");
+const token = "test-token";
+const alreadyEnabledError = {
+    output: "[ERROR]: unable to enable environment (you already have an enabled environment)"
+};
+
+const loadZrokManager = responses => {
+    const calls = [];
+    const logs = {
+        debug: [],
+        error: [],
+        info: []
+    };
+    const executeCommand = async (...args) => {
+        calls.push(args);
+        const response = responses.shift();
+        if (!response) throw new Error("Unexpected ProcessSpawner call");
+        if ("error" in response) throw response.error;
+        return response.output;
+    };
+    const logger = {
+        debug: (...args) => logs.debug.push(args),
+        error: (...args) => logs.error.push(args),
+        info: (...args) => logs.info.push(args)
+    };
+
+    const { ZrokManager } = loadTypeScriptModule(zrokManagerPath, {
+        axios: { post: async () => undefined },
+        child_process: { spawn: () => undefined },
+        electron: { app: { getVersion: () => "test" } },
+        "@server": { Server: () => undefined },
+        "@server/fileSystem": { FileSystem: { resources: "/resources" } },
+        "@server/helpers/utils": {
+            isEmpty: value => value == null || value.length === 0,
+            isNotEmpty: value => value != null && value.length > 0
+        },
+        "@server/lib/logging/Loggable": {
+            Loggable: class {},
+            getLogger: () => logger
+        },
+        "@server/lib/ProcessSpawner": {
+            ProcessSpawner: { executeCommand }
+        }
+    });
+
+    return { calls, logs, ZrokManager };
+};
+
+const success = output => ({ output });
+const failure = output => ({ error: { output } });
+const expectedCall = (ZrokManager, args) => [ZrokManager.daemonPath, args, {}, "ZrokManager"];
+
+test("returns the output when zrok enables normally", async () => {
+    const { calls, ZrokManager } = loadZrokManager([success("environment enabled")]);
+
+    assert.equal(await ZrokManager.setToken(token), "environment enabled");
+    assert.deepEqual(calls, [expectedCall(ZrokManager, ["enable", token])]);
+});
+
+test("preserves invalid-token errors without disabling or retrying", async () => {
+    const { calls, ZrokManager } = loadZrokManager([failure("[ERROR]: enableUnauthorized")]);
+
+    await assert.rejects(() => ZrokManager.setToken(token), { message: "Invalid Zrok token!" });
+    assert.deepEqual(calls, [expectedCall(ZrokManager, ["enable", token])]);
+});
+
+test("preserves generic enable errors without disabling or retrying", async () => {
+    const { calls, ZrokManager } = loadZrokManager([failure("[ERROR]: network unavailable")]);
+
+    await assert.rejects(() => ZrokManager.setToken(token), {
+        message: "Failed to set Zrok token! Please check your server logs for more information."
+    });
+    assert.deepEqual(calls, [expectedCall(ZrokManager, ["enable", token])]);
+});
+
+test("disables a stale environment and retries enable exactly once", async () => {
+    const { calls, ZrokManager } = loadZrokManager([
+        { error: alreadyEnabledError },
+        success("environment disabled"),
+        success("environment enabled")
+    ]);
+
+    assert.equal(await ZrokManager.setToken(token), "environment enabled");
+    assert.deepEqual(calls, [
+        expectedCall(ZrokManager, ["enable", token]),
+        expectedCall(ZrokManager, ["disable"]),
+        expectedCall(ZrokManager, ["enable", token])
+    ]);
+});
+
+test("does not retry again when the second enable fails", async () => {
+    const { calls, ZrokManager } = loadZrokManager([
+        { error: alreadyEnabledError },
+        success("environment disabled"),
+        { error: alreadyEnabledError }
+    ]);
+
+    await assert.rejects(() => ZrokManager.setToken(token), {
+        message: "Failed to set Zrok token! Please check your server logs for more information."
+    });
+    assert.deepEqual(calls, [
+        expectedCall(ZrokManager, ["enable", token]),
+        expectedCall(ZrokManager, ["disable"]),
+        expectedCall(ZrokManager, ["enable", token])
+    ]);
+});
+
+test("preserves invalid-token errors from the retry", async () => {
+    const { calls, ZrokManager } = loadZrokManager([
+        { error: alreadyEnabledError },
+        success("environment disabled"),
+        failure("[ERROR]: enableUnauthorized")
+    ]);
+
+    await assert.rejects(() => ZrokManager.setToken(token), { message: "Invalid Zrok token!" });
+    assert.deepEqual(calls, [
+        expectedCall(ZrokManager, ["enable", token]),
+        expectedCall(ZrokManager, ["disable"]),
+        expectedCall(ZrokManager, ["enable", token])
+    ]);
+});

--- a/packages/server/test/zrokManager.test.cjs
+++ b/packages/server/test/zrokManager.test.cjs
@@ -139,3 +139,15 @@ test("preserves invalid-token errors from the retry", async () => {
         expectedCall(ZrokManager, ["enable", token])
     ]);
 });
+
+test("stops recovery and preserves the disable error when stale-environment cleanup fails", async () => {
+    const { calls, ZrokManager } = loadZrokManager([
+        { error: alreadyEnabledError },
+        failure("[ERROR]: environment is still in use")
+    ]);
+
+    await assert.rejects(() => ZrokManager.setToken(token), {
+        message: "Failed to disable Zrok tunnel! Please check your server logs for more information."
+    });
+    assert.deepEqual(calls, [expectedCall(ZrokManager, ["enable", token]), expectedCall(ZrokManager, ["disable"])]);
+});


### PR DESCRIPTION
## Summary

- detect zrok's exact `you already have an enabled environment` failure when setting an auth token
- disable that stale local environment and retry `zrok enable <token>` exactly once
- stop immediately if cleanup fails and preserve the existing disable error
- keep existing invalid-token and generic-error behavior for both the initial attempt and retry
- add focused `ProcessSpawner.executeCommand` tests for the bounded recovery paths

## Root cause

`ZrokManager.setToken()` recognized the stale-environment error but returned its output as though token setup had succeeded. The stale environment remained enabled, so later share creation could continue failing. The issue's manual workaround—running `zrok disable` before enabling through BlueBubbles—showed the required recovery sequence.

## Behavior and safety

Only output containing the existing exact zrok condition triggers recovery. The sequence is bounded to:

1. `zrok enable <token>`
2. `zrok disable` if the stale-environment condition is returned
3. one final `zrok enable <token>` attempt

There is no recursion or unbounded retry. If `disable` fails, recovery stops before a second enable and preserves `Failed to disable Zrok tunnel!`. Invalid tokens remain `Invalid Zrok token!`; unrelated failures retain the existing generic error.

## Validation

Validated on current head `0cd1cb84`:

- `npm run test:zrok --workspace packages/server` — 7/7 tests passed
- the committed seventh test verifies that a failed disable stops at `enable → disable`, performs no second enable, and preserves the exact existing disable error
- targeted ESLint, Prettier, and `git diff --check` passed

## Limitation

No recovery was run against a real disposable zrok token/environment. The command sequence and errors are validated at the mocked `ProcessSpawner` boundary; this PR does not claim an end-to-end live zrok recovery pass.

The broader server type-check still reaches the pre-existing unrelated `ScheduledService.ts:39` `NodeJS.Timer`/`clearInterval` error.

Fixes #678
