### PR TITLE
Fix development production build and migration startup

### DIFF
--- a/packages/server/src/server/databases/server/migrations/1750299580000-AddExternalIdToContacts.ts
+++ b/packages/server/src/server/databases/server/migrations/1750299580000-AddExternalIdToContacts.ts
@@ -1,6 +1,8 @@
 import { MigrationInterface, QueryRunner, TableColumn, TableIndex } from "typeorm";
 
 export class AddExternalIdToContacts1750299580000 implements MigrationInterface {
+    name = "AddExternalIdToContacts1750299580000";
+
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.addColumn(
             "contact",

--- a/packages/server/src/server/lib/ScheduledService.ts
+++ b/packages/server/src/server/lib/ScheduledService.ts
@@ -5,7 +5,7 @@ export class ScheduledService extends EventEmitter {
 
     action: () => void;
 
-    handle: NodeJS.Timer;
+    handle: NodeJS.Timeout;
 
     interval: number;
 


### PR DESCRIPTION
## Summary

- use `NodeJS.Timeout` for scheduled interval handles so the production TypeScript build accepts `clearInterval`
- give `AddExternalIdToContacts1750299580000` an explicit migration name so TypeORM can identify it after production minification

## Why

The packaged development build currently fails in two places:

1. TypeScript rejects `NodeJS.Timer` when it is passed to `clearInterval` with the current locked typings.
2. When upgrading an existing server database, the production-minified contact migration has the runtime class name `t`. TypeORM requires migration names to end in a 13-digit timestamp and aborts startup with:

   `t migration name is wrong. Migration class name should have a JavaScript timestamp appended.`

The older migrations already define an explicit `name` property for this reason.

## Verification

- ESLint passes for both changed files.
- `npm run build --workspace @bluebubbles/server` succeeds.
- A packaged ARM64 build starts successfully against an existing BlueBubbles 1.9.9 configuration database on macOS 15.7.7.
