### PR TITLE
Make the iMessage DB watcher survive WAL replacement

### DIFF
--- a/packages/server/src/server/databases/imessage/listeners/IMessageListener.ts
+++ b/packages/server/src/server/databases/imessage/listeners/IMessageListener.ts
@@ -50,6 +50,7 @@ export class IMessageListener extends Loggable {
 
     stop() {
         this.stopped = true;
+        this.watcher?.stop();
         this.removeAllListeners();
     }
 
@@ -60,9 +61,13 @@ export class IMessageListener extends Loggable {
     getEarliestModifiedDate() {
         let earliest = new Date();
         for (const filePath of this.filePaths) {
-            const stat = fs.statSync(filePath);
-            if (stat.mtime < earliest) {
-                earliest = stat.mtime;
+            try {
+                const stat = fs.statSync(filePath);
+                if (stat.mtime < earliest) {
+                    earliest = stat.mtime;
+                }
+            } catch (error) {
+                this.log.debug(`Unable to stat ${filePath}: ${error}`);
             }
         }
 
@@ -70,13 +75,10 @@ export class IMessageListener extends Loggable {
     }
 
     async start() {
-        this.lastCheck = this.getEarliestModifiedDate().getTime() - 60000;
+        this.lastCheck = this.getEarliestModifiedDate().getTime();
         this.stopped = false;
 
-        // Perform an initial poll to kinda seed the cache.
-        // We'll use the earliest modified date of the files to determine the initial poll date.
-        // We'll also subtract 1 minute just to pre-load the cache with a little bit of data.
-        await this.poll(new Date(this.lastCheck), false);
+        await this.poll(new Date(this.lastCheck));
 
         this.watcher = new MultiFileWatcher(this.filePaths);
         this.watcher.on("change", async (event: FileChangeEvent) => {

--- a/packages/server/src/server/lib/MultiFileWatcher.ts
+++ b/packages/server/src/server/lib/MultiFileWatcher.ts
@@ -1,5 +1,6 @@
 import EventEmitter from "events";
 import fs from "fs";
+import path from "path";
 
 export type FileStat = fs.Stats | null | undefined;
 
@@ -11,14 +12,20 @@ export type FileChangeEvent = {
     filePath: string;
 };
 
+const MAX_CONSECUTIVE_REARMS = 5;
+
 export class MultiFileWatcher extends EventEmitter {
     tag = "MultiFileWatcher";
 
     private readonly filePaths: string[];
 
-    private watchers: fs.FSWatcher[] = [];
+    private watchers: Map<string, fs.FSWatcher> = new Map();
+
+    private rearmAttempts: Map<string, number> = new Map();
 
     private previousStats: Record<string, FileStat> = {};
+
+    private stopped = true;
 
     constructor(filePaths: string[]) {
         super();
@@ -26,41 +33,123 @@ export class MultiFileWatcher extends EventEmitter {
     }
 
     start() {
+        if (!this.stopped) return;
+        this.stopped = false;
+
         for (const filePath of this.filePaths) {
-            this.watchFile(filePath);
+            this.previousStats[filePath] = MultiFileWatcher.statOrNull(filePath);
+        }
+
+        for (const dirPath of this.watchedDirectories()) {
+            this.watchDirectory(dirPath);
         }
     }
 
-    private watchFile(filePath: string) {
-        // Load the initial stats if the file exists
-        if (fs.existsSync(filePath)) {
-            this.previousStats[filePath] = fs.statSync(filePath);
+    stop() {
+        this.stopped = true;
+
+        for (const watcher of this.watchers.values()) {
+            watcher.removeAllListeners();
+            watcher.close();
         }
 
-        const watcher = fs.watch(filePath, { encoding: "utf8", persistent: false, recursive: false });
-        watcher.on("change", async (eventType, _) => {
-            if (eventType !== "change") return;
+        this.watchers.clear();
+        this.rearmAttempts.clear();
+    }
 
-            const currentStat = await fs.promises.stat(filePath);
-            this.emit("change", {
-                filePath,
-                prevStat: { ...this.previousStats[filePath] },
-                currentStat: { ...currentStat }
-            });
+    private watchedDirectories(): string[] {
+        return Array.from(new Set(this.filePaths.map(filePath => path.dirname(filePath))));
+    }
 
-            this.previousStats[filePath] = currentStat;
+    private watchDirectory(dirPath: string) {
+        if (this.stopped || this.watchers.has(dirPath)) return;
+
+        let watcher: fs.FSWatcher;
+
+        try {
+            watcher = fs.watch(dirPath, { encoding: "utf8", persistent: false, recursive: false });
+        } catch (error) {
+            this.emit("error", error);
+            this.rearm(dirPath);
+            return;
+        }
+
+        watcher.on("change", (_eventType, fileName) => {
+            this.rearmAttempts.delete(dirPath);
+
+            const affected = this.affectedPaths(dirPath, fileName ? fileName.toString() : null);
+            if (affected.length === 0) return;
+
+            this.detectChanges(affected);
         });
 
         watcher.on("error", error => {
             this.emit("error", error);
+            this.rearm(dirPath);
         });
 
-        this.watchers.push(watcher);
+        this.watchers.set(dirPath, watcher);
     }
 
-    stop() {
-        for (const watcher of this.watchers) {
-            watcher.close();
+    private rearm(dirPath: string) {
+        if (this.stopped) return;
+
+        const existing = this.watchers.get(dirPath);
+        if (existing) {
+            existing.removeAllListeners();
+            existing.close();
+            this.watchers.delete(dirPath);
+        }
+
+        const attempts = (this.rearmAttempts.get(dirPath) ?? 0) + 1;
+        if (attempts > MAX_CONSECUTIVE_REARMS) {
+            this.emit("error", new Error(`Stopped watching ${dirPath} after ${attempts} consecutive failures`));
+            return;
+        }
+
+        this.rearmAttempts.set(dirPath, attempts);
+        this.watchDirectory(dirPath);
+    }
+
+    private affectedPaths(dirPath: string, fileName: string | null): string[] {
+        const inDirectory = this.filePaths.filter(filePath => path.dirname(filePath) === dirPath);
+        if (!fileName) return inDirectory;
+        return inDirectory.filter(filePath => fileName.startsWith(path.basename(filePath)));
+    }
+
+    private detectChanges(filePaths: string[]) {
+        if (this.stopped) return;
+
+        for (const filePath of filePaths) {
+            const previousStat = this.previousStats[filePath];
+            const currentStat = MultiFileWatcher.statOrNull(filePath);
+            if (!MultiFileWatcher.hasChanged(previousStat, currentStat)) continue;
+
+            this.previousStats[filePath] = currentStat;
+            this.emit("change", {
+                filePath,
+                prevStat: previousStat ? { ...previousStat } : previousStat,
+                currentStat: currentStat ? { ...currentStat } : currentStat
+            });
+        }
+    }
+
+    private static hasChanged(previousStat: FileStat, currentStat: FileStat): boolean {
+        if (!previousStat && !currentStat) return false;
+        if (!previousStat || !currentStat) return true;
+
+        return (
+            previousStat.mtimeMs !== currentStat.mtimeMs ||
+            previousStat.size !== currentStat.size ||
+            previousStat.ino !== currentStat.ino
+        );
+    }
+
+    private static statOrNull(filePath: string): FileStat {
+        try {
+            return fs.statSync(filePath);
+        } catch (error) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes #843.

### The problem

`MultiFileWatcher` watches `chat.db` and `chat.db-wal` with `fs.watch()` on the file paths. On macOS that binds to the inode. SQLite deletes and recreates `chat.db-wal`, most reliably when Messages.app is killed — which the Private API does on every startup, roughly 40ms after the chat listener arms. Once that happens the watcher is permanently deaf and the server receives nothing until it restarts, whereupon it happens again.

It cannot self-heal: `rename` events are discarded, the `error` handler never re-arms, and nothing polls as a fallback.

### What it solves

Receiving survives the WAL being replaced, so the Private API no longer silently disables inbound messages. It also fixes the knock-on in #843 where outgoing `MessagePromise`s never resolve, because `messageManager.resolve()` only runs inside `MessagePoller.poll()`.

### How it is fixed

**`lib/MultiFileWatcher.ts`** — watch each file's parent directory instead of the file. Directory inodes are stable across WAL replacement, which removes the failure class rather than patching around it. Directory events are filtered to the watched files by name, then confirmed by comparing `mtimeMs`, `size` and `ino` before emitting, so the emitted `FileChangeEvent` shape is unchanged for consumers. Watches re-arm on error, bounded by a consecutive-failure count that resets on any successful event, so a permanently bad path cannot spin. `stop()` now fully tears down.

**`databases/imessage/listeners/IMessageListener.ts`**

- `stop()` now stops the watcher. It previously did not, leaking watchers across service restarts.
- the startup poll now emits its results. It previously ran with `emitResults = false`, which loaded every recent message into the dedupe cache without delivering any, so a restart silently swallowed the backlog instead of catching up.
- `getEarliestModifiedDate()` tolerates a missing file rather than throwing. `chat.db-wal` legitimately does not exist after a clean checkpoint.

### Not included

The startup ordering (listeners arming before dylib injection) is deliberately left alone. With a watcher that survives inode replacement it is no longer load-bearing, and sequencing service startup is a larger change worth discussing separately.

### Verification

On an affected machine `New Message from` and `Priority: high` were both 0 across 20 days and ~174 process starts. Both go non-zero on the first received message with this change.